### PR TITLE
HOTT-116 suppress quotas + P&R national measures for XI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ data/failed-measures-report*
 
 # Environment files
 .env
+.env.*.local
 
 # Cloud Foundry manifest files
 *_manifest.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -116,17 +116,13 @@ SpaceInsideParens:
   Description: No spaces after ( or before ).
   Enabled: true
 
-Tab:
-  Description: No hard tabs.
-  Enabled: true
-
 # Supports --auto-correct
 TrailingWhitespace:
   Description: Avoid trailing whitespace.
   Enabled: true
 
 # Supports --auto-correct
-TrailingBlankLines:
+TrailingEmptyLines:
   Description: Checks trailing blank lines and final newline.
   Enabled: true
   EnforcedStyle: final_newline
@@ -257,7 +253,7 @@ TrivialAccessors:
   ExactNameMatch: true
   AllowPredicates: true
   AllowDSLWriters: false
-  Whitelist:
+  AllowedMethods:
     - to_ary
     - to_a
     - to_c
@@ -276,7 +272,7 @@ TrivialAccessors:
     - to_s
     - to_sym
 
-VariableName:
+Naming/VariableName:
   Description: Use the configured style when naming variables.
   Enabled: true
   EnforcedStyle: snake_case
@@ -294,7 +290,7 @@ RescueException:
 ## Collections
 
 # Supports --auto-correct
-AlignArray:
+ArrayAlignment:
   Description: Align the elements of an array literal if they span more than one line.
   Enabled: true
 
@@ -334,7 +330,7 @@ MultilineMethodCallIndentation:
 ## Strings
 
 # Supports --auto-correct
-StringConversionInInterpolation:
+RedundantStringCoercion:
   Description: Checks for Object#to_s usage in string interpolation.
   Enabled: true
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Please go through this updated [setup document](https://github.com/bitzesty/trad
 
     bin/setup
 
-2. Update `.env` file with valid data.
+2. Update `.env` file with valid data. To enable the XI version, add the extra flag `SERVICE=xi`. If not added, it will default to the UK version.
 
 3. Start Foreman.
 

--- a/app/models/measure_type.rb
+++ b/app/models/measure_type.rb
@@ -5,10 +5,13 @@
 class MeasureType < Sequel::Model
   IMPORT_MOVEMENT_CODES = [0, 2].freeze
   EXPORT_MOVEMENT_CODES = [1, 2].freeze
-  EXCLUDED_TYPES = %w[442 SPL].freeze
   THIRD_COUNTRY = '103'.freeze
   VAT_TYPES = %w[VTA VTE VTS VTZ 305].freeze
   SUPPLEMENTARY_TYPES = %w[109 110 111].freeze
+  QUOTA_TYPES= %w[046 122 123 143 146 147 653 654].freeze
+  EXCLUDED_TYPES = %w[442 SPL].tap do |types|
+    types.concat(QUOTA_TYPES) if TradeTariffBackend.service == 'xi'
+  end.freeze
 
   plugin :time_machine, period_start_column: :measure_types__validity_start_date,
                         period_end_column:   :measure_types__validity_end_date

--- a/app/models/measure_type.rb
+++ b/app/models/measure_type.rb
@@ -8,9 +8,10 @@ class MeasureType < Sequel::Model
   THIRD_COUNTRY = '103'.freeze
   VAT_TYPES = %w[VTA VTE VTS VTZ 305].freeze
   SUPPLEMENTARY_TYPES = %w[109 110 111].freeze
-  QUOTA_TYPES= %w[046 122 123 143 146 147 653 654].freeze
+  QUOTA_TYPES = %w[046 122 123 143 146 147 653 654].freeze
+  NATIONAL_PR_TYPES = %w[ATT CEX CHM COE COI CVD DPO ECM EHC EQC EWP HOP HSE IWP PHC PRE PRT QRC SFS].freeze
   EXCLUDED_TYPES = %w[442 SPL].tap do |types|
-    types.concat(QUOTA_TYPES) if TradeTariffBackend.service == 'xi'
+    types.concat(QUOTA_TYPES + NATIONAL_PR_TYPES) if TradeTariffBackend.service == 'xi'
   end.freeze
 
   plugin :time_machine, period_start_column: :measure_types__validity_start_date,

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -17,6 +17,7 @@ Rails.application.configure do
   config.action_controller.perform_caching = false
 
   # config.cache_store = :memory_store, { size: 20.megabytes }
+  config.cache_store = [:null_store]
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/lib/trade_tariff_backend.rb
+++ b/lib/trade_tariff_backend.rb
@@ -39,6 +39,10 @@ module TradeTariffBackend
       Rails.env
     end
 
+    def service
+      ENV.fetch('SERVICE', 'uk')
+    end
+
     def deployed_environment
       PaasConfig.space
     end

--- a/spec/models/commodity_spec.rb
+++ b/spec/models/commodity_spec.rb
@@ -122,18 +122,51 @@ describe Commodity do
     end
 
     describe 'measures' do
-      let(:measure_type) { create :measure_type, measure_type_id: MeasureType::EXCLUDED_TYPES.sample }
-      let(:commodity)    { create :commodity, :with_indent }
-      let(:measure)      {
-        create :measure, measure_type_id: measure_type.measure_type_id,
-                                            goods_nomenclature_sid: commodity.goods_nomenclature_sid
-      }
+      let(:commodity) { create :commodity, :with_indent }
+      let(:excluded_for_both_uk_xi) { '442' }
+      let(:excluded_for_xi) { '653' }
 
-      it 'does not include measures for excluded measure types' do
-        measure_type
-        measure
+      before do
+        allow(TradeTariffBackend).to receive(:service).and_return(service)
 
-        expect(commodity.measures.map(&:measure_sid)).not_to include measure.measure_sid
+        # Reloads the module to update the EXCLUDED_TYPES value after stubbing the service
+        load Rails.root.join("app/models/measure_type.rb")
+      end
+
+      context 'when the service version is the UK' do
+        let(:service) { 'uk' }
+
+        it 'does not include measures that are excluded for the UK service' do
+          measure_type = create(:measure_type, measure_type_id: excluded_for_both_uk_xi)
+          measure = create(:measure, measure_type_id: measure_type.measure_type_id, goods_nomenclature_sid: commodity.goods_nomenclature_sid)
+
+          expect(commodity.measures.map(&:measure_sid)).not_to include measure.measure_sid
+        end
+
+        it 'does include measures that are only excluded for the XI service' do
+          measure_type = create(:measure_type, measure_type_id: excluded_for_xi)
+          measure = create(:measure, measure_type_id: measure_type.measure_type_id, goods_nomenclature_sid: commodity.goods_nomenclature_sid)
+
+          expect(commodity.measures.map(&:measure_sid)).to include measure.measure_sid
+        end
+      end
+
+      context 'when the service version is the XI' do
+        let(:service) { 'xi' }
+
+        it 'does not include measures that were also excluded for the UK service' do
+          measure_type = create(:measure_type, measure_type_id: excluded_for_both_uk_xi)
+          measure = create(:measure, measure_type_id: measure_type.measure_type_id, goods_nomenclature_sid: commodity.goods_nomenclature_sid)
+
+          expect(commodity.measures.map(&:measure_sid)).not_to include measure.measure_sid
+        end
+
+        it 'does not include measures that are only excluded for the XI service' do
+          measure_type = create(:measure_type, measure_type_id: excluded_for_xi)
+          measure = create(:measure,  measure_type_id: measure_type.measure_type_id, goods_nomenclature_sid: commodity.goods_nomenclature_sid)
+
+          expect(commodity.measures.map(&:measure_sid)).not_to include measure.measure_sid
+        end
       end
     end
 

--- a/spec/models/commodity_spec.rb
+++ b/spec/models/commodity_spec.rb
@@ -124,7 +124,8 @@ describe Commodity do
     describe 'measures' do
       let(:commodity) { create :commodity, :with_indent }
       let(:excluded_for_both_uk_xi) { '442' }
-      let(:excluded_for_xi) { '653' }
+      let(:excluded_quota_for_xi) { '653' }
+      let(:excluded_pr_for_xi) { 'CEX' }
 
       before do
         allow(TradeTariffBackend).to receive(:service).and_return(service)
@@ -143,8 +144,15 @@ describe Commodity do
           expect(commodity.measures.map(&:measure_sid)).not_to include measure.measure_sid
         end
 
-        it 'does include measures that are only excluded for the XI service' do
-          measure_type = create(:measure_type, measure_type_id: excluded_for_xi)
+        it 'does include quota measures that are only excluded for the XI service' do
+          measure_type = create(:measure_type, measure_type_id: excluded_quota_for_xi)
+          measure = create(:measure, measure_type_id: measure_type.measure_type_id, goods_nomenclature_sid: commodity.goods_nomenclature_sid)
+
+          expect(commodity.measures.map(&:measure_sid)).to include measure.measure_sid
+        end
+
+        it 'does include P&R national measures that are only excluded for the XI service' do
+          measure_type = create(:measure_type, measure_type_id: excluded_pr_for_xi)
           measure = create(:measure, measure_type_id: measure_type.measure_type_id, goods_nomenclature_sid: commodity.goods_nomenclature_sid)
 
           expect(commodity.measures.map(&:measure_sid)).to include measure.measure_sid
@@ -161,8 +169,15 @@ describe Commodity do
           expect(commodity.measures.map(&:measure_sid)).not_to include measure.measure_sid
         end
 
-        it 'does not include measures that are only excluded for the XI service' do
-          measure_type = create(:measure_type, measure_type_id: excluded_for_xi)
+        it 'does not include quota measures that are only excluded for the XI service' do
+          measure_type = create(:measure_type, measure_type_id: excluded_quota_for_xi)
+          measure = create(:measure,  measure_type_id: measure_type.measure_type_id, goods_nomenclature_sid: commodity.goods_nomenclature_sid)
+
+          expect(commodity.measures.map(&:measure_sid)).not_to include measure.measure_sid
+        end
+
+        it 'does not include P&R national measures that are only excluded for the XI service' do
+          measure_type = create(:measure_type, measure_type_id: excluded_pr_for_xi)
           measure = create(:measure,  measure_type_id: measure_type.measure_type_id, goods_nomenclature_sid: commodity.goods_nomenclature_sid)
 
           expect(commodity.measures.map(&:measure_sid)).not_to include measure.measure_sid

--- a/spec/models/heading_spec.rb
+++ b/spec/models/heading_spec.rb
@@ -62,7 +62,8 @@ describe Heading do
     describe 'measures' do
       let(:heading) { create :commodity, :with_indent }
       let(:excluded_for_both_uk_xi) { '442' }
-      let(:excluded_for_xi) { '653' }
+      let(:excluded_quota_for_xi) { '653' }
+      let(:excluded_pr_for_xi) { 'CEX' }
 
       before do
         allow(TradeTariffBackend).to receive(:service).and_return(service)
@@ -81,8 +82,15 @@ describe Heading do
           expect(heading.measures.map(&:measure_sid)).not_to include measure.measure_sid
         end
 
-        it 'does include measures that are only excluded for the XI service' do
-          measure_type = create(:measure_type, measure_type_id: excluded_for_xi)
+        it 'does include quota measures that are only excluded for the XI service' do
+          measure_type = create(:measure_type, measure_type_id: excluded_quota_for_xi)
+          measure = create(:measure, measure_type_id: measure_type.measure_type_id, goods_nomenclature_sid: heading.goods_nomenclature_sid)
+
+          expect(heading.measures.map(&:measure_sid)).to include measure.measure_sid
+        end
+
+        it 'does include P&R national measures that are only excluded for the XI service' do
+          measure_type = create(:measure_type, measure_type_id: excluded_pr_for_xi)
           measure = create(:measure, measure_type_id: measure_type.measure_type_id, goods_nomenclature_sid: heading.goods_nomenclature_sid)
 
           expect(heading.measures.map(&:measure_sid)).to include measure.measure_sid
@@ -99,8 +107,15 @@ describe Heading do
           expect(heading.measures.map(&:measure_sid)).not_to include measure.measure_sid
         end
 
-        it 'does not include measures that are only excluded for the XI service' do
-          measure_type = create(:measure_type, measure_type_id: excluded_for_xi)
+        it 'does not include quota measures that are only excluded for the XI service' do
+          measure_type = create(:measure_type, measure_type_id: excluded_quota_for_xi)
+          measure = create(:measure, measure_type_id: measure_type.measure_type_id, goods_nomenclature_sid: heading.goods_nomenclature_sid)
+
+          expect(heading.measures.map(&:measure_sid)).not_to include measure.measure_sid
+        end
+
+        it 'does not include national P&R national measures that are only excluded for the XI service' do
+          measure_type = create(:measure_type, measure_type_id: excluded_pr_for_xi)
           measure = create(:measure, measure_type_id: measure_type.measure_type_id, goods_nomenclature_sid: heading.goods_nomenclature_sid)
 
           expect(heading.measures.map(&:measure_sid)).not_to include measure.measure_sid

--- a/spec/models/heading_spec.rb
+++ b/spec/models/heading_spec.rb
@@ -60,20 +60,51 @@ describe Heading do
     end
 
     describe 'measures' do
-      let(:measure_type) { create :measure_type, measure_type_id: MeasureType::EXCLUDED_TYPES.sample }
-      let(:heading)      { create :heading, :with_indent }
-      let(:measure)      {
-        create :measure, measure_type_id: measure_type.measure_type_id,
-                                            goods_nomenclature_sid: heading.goods_nomenclature_sid
-      }
+      let(:heading) { create :commodity, :with_indent }
+      let(:excluded_for_both_uk_xi) { '442' }
+      let(:excluded_for_xi) { '653' }
 
-      it 'does not include measures for excluded measure types' do
-        measure_type
-        measure
+      before do
+        allow(TradeTariffBackend).to receive(:service).and_return(service)
 
-        expect(
-          heading.measures.map(&:measure_sid)
-        ).not_to include measure.measure_sid
+        # Reloads the module to update the EXCLUDED_TYPES value after stubbing the service
+        load Rails.root.join("app/models/measure_type.rb")
+      end
+
+      context 'when the service version is the UK' do
+        let(:service) { 'uk' }
+
+        it 'does not include measures that are excluded for the UK service' do
+          measure_type = create(:measure_type, measure_type_id: excluded_for_both_uk_xi)
+          measure = create(:measure, measure_type_id: measure_type.measure_type_id, goods_nomenclature_sid: heading.goods_nomenclature_sid)
+
+          expect(heading.measures.map(&:measure_sid)).not_to include measure.measure_sid
+        end
+
+        it 'does include measures that are only excluded for the XI service' do
+          measure_type = create(:measure_type, measure_type_id: excluded_for_xi)
+          measure = create(:measure, measure_type_id: measure_type.measure_type_id, goods_nomenclature_sid: heading.goods_nomenclature_sid)
+
+          expect(heading.measures.map(&:measure_sid)).to include measure.measure_sid
+        end
+      end
+
+      context 'when the service version is XI' do
+        let(:service) { 'xi' }
+
+        it 'does not include measures that were also excluded for the UK service' do
+          measure_type = create(:measure_type, measure_type_id: excluded_for_both_uk_xi)
+          measure = create(:measure, measure_type_id: measure_type.measure_type_id, goods_nomenclature_sid: heading.goods_nomenclature_sid)
+
+          expect(heading.measures.map(&:measure_sid)).not_to include measure.measure_sid
+        end
+
+        it 'does not include measures that are only excluded for the XI service' do
+          measure_type = create(:measure_type, measure_type_id: excluded_for_xi)
+          measure = create(:measure, measure_type_id: measure_type.measure_type_id, goods_nomenclature_sid: heading.goods_nomenclature_sid)
+
+          expect(heading.measures.map(&:measure_sid)).not_to include measure.measure_sid
+        end
       end
     end
 

--- a/spec/models/measure_type_spec.rb
+++ b/spec/models/measure_type_spec.rb
@@ -34,11 +34,6 @@ describe MeasureType do
       }
 
       it 'defines the correct EXCLUDED_TYPES list' do
-        allow(TradeTariffBackend).to receive(:service).and_return('xi')
-
-        # Reloads the module to update the EXCLUDED_TYPES value after stubbing the service
-        load Rails.root.join("app/models/measure_type.rb")
-
         expect(described_class::EXCLUDED_TYPES).to eq(excluded_types)
       end
     end

--- a/spec/models/measure_type_spec.rb
+++ b/spec/models/measure_type_spec.rb
@@ -29,7 +29,9 @@ describe MeasureType do
 
     context 'when the service is the XI version' do
       let(:service) { 'xi' }
-      let(:excluded_types) { %w[442 SPL].concat(described_class::QUOTA_TYPES) }
+      let(:excluded_types) {
+        %w[442 SPL].concat(described_class::QUOTA_TYPES + described_class::NATIONAL_PR_TYPES)
+      }
 
       it 'defines the correct EXCLUDED_TYPES list' do
         allow(TradeTariffBackend).to receive(:service).and_return('xi')

--- a/spec/models/measure_type_spec.rb
+++ b/spec/models/measure_type_spec.rb
@@ -10,6 +10,38 @@ describe MeasureType do
     it { is_expected.to validate_presence.of(:measure_type_series) }
   end
 
+  describe 'constants' do
+    before do
+      allow(TradeTariffBackend).to receive(:service).and_return(service)
+
+      # Reloads the module to update the EXCLUDED_TYPES value after stubbing the service
+      load Rails.root.join("app/models/measure_type.rb")
+    end
+
+    context 'when the service is the UK version' do
+      let(:service) { 'uk' }
+      let(:excluded_types) { %w[442 SPL] }
+
+      it 'defines the correct EXCLUDED_TYPES list' do
+        expect(described_class::EXCLUDED_TYPES).to eq(excluded_types)
+      end
+    end
+
+    context 'when the service is the XI version' do
+      let(:service) { 'xi' }
+      let(:excluded_types) { %w[442 SPL].concat(described_class::QUOTA_TYPES) }
+
+      it 'defines the correct EXCLUDED_TYPES list' do
+        allow(TradeTariffBackend).to receive(:service).and_return('xi')
+
+        # Reloads the module to update the EXCLUDED_TYPES value after stubbing the service
+        load Rails.root.join("app/models/measure_type.rb")
+
+        expect(described_class::EXCLUDED_TYPES).to eq(excluded_types)
+      end
+    end
+  end
+
   describe '#excise?' do
     context 'measure type is Excise related' do
       let(:measure_type) { build :measure_type, measure_type_series_id: 'Q' }


### PR DESCRIPTION
## Context

Suppress QUOTAS for the XI service version

This PR introduces the following:
- service config UK/XI using an ENV flag called SERVICE
- filter out the QUOTAs for the XI version of the service
- filter out the P&R national measures for XI version fo the service
- measure type ids associated with quotas that must be suppressed:
'046', '122', '123', '143', '146', '147', '653', '654'
- measure type ids for P&R national that must suppressed:
'ATT', 'CEX', 'CHM', 'COE', 'COI', 'CVD', 'DPO', 'ECM', 'EHC', 'EQC', 'EWP', 'HOP', 'HSE', 'IWP', 'PHC', 'PRE', 'PRT', 'QRC', 'SFS'
- Affected components: API - v1 and v2
- Backwards compatible
- Fix Rubocop broken config

## Ticket
https://transformuk.atlassian.net/jira/software/projects/HOTT/boards/96?selectedIssue=HOTT-116