### PR TITLE
Map measurementUnitQualifierCode field correctly

### DIFF
--- a/lib/cds_importer/entity_mapper/quota_definition_mapper.rb
+++ b/lib/cds_importer/entity_mapper/quota_definition_mapper.rb
@@ -18,7 +18,7 @@ class CdsImporter
         "criticalThreshold" => :critical_threshold,
         "monetaryUnit.monetaryUnitCode" => :monetary_unit_code,
         "measurementUnit.measurementUnitCode" => :measurement_unit_code,
-        "measurementUnit.measurementUnitQualifierCode" => :measurement_unit_qualifier_code,
+        "measurementUnitQualifier.measurementUnitQualifierCode" => :measurement_unit_qualifier_code,
         "description" => :description
       ).freeze
 

--- a/spec/integration/cds_importer/entity_mappers_spec.rb
+++ b/spec/integration/cds_importer/entity_mappers_spec.rb
@@ -1844,6 +1844,8 @@ describe CdsImporter::EntityMapper do
       },
       "measurementUnit" => {
         "measurementUnitCode" => "KGM",
+      },
+      "measurementUnitQualifier" => {
         "measurementUnitQualifierCode" => "X"
       },
       "monetaryUnit" => {
@@ -1867,7 +1869,7 @@ describe CdsImporter::EntityMapper do
     expect(entity.description).to eq(values["description"])
     expect(entity.monetary_unit_code).to eq(values["monetaryUnit"]["monetaryUnitCode"])
     expect(entity.measurement_unit_code).to eq(values["measurementUnit"]["measurementUnitCode"])
-    expect(entity.measurement_unit_qualifier_code).to eq(values["measurementUnit"]["measurementUnitQualifierCode"])
+    expect(entity.measurement_unit_qualifier_code).to eq(values["measurementUnitQualifier"]["measurementUnitQualifierCode"])
     expect(entity.maximum_precision.to_s.to_s).to eq(values["maximumPrecision"])
     expect(entity.critical_state).to eq(values["criticalState"])
     expect(entity.critical_threshold.to_s).to eq(values["criticalThreshold"])


### PR DESCRIPTION
# Description

The field called measurementUnitQualifierCode is now
nested under measurementUnitQualifier in the XML files,
therefore, the mapping inside the EntityMapper
needs to change.

Here's an example of the XML file:

```ruby
<measurementUnitQualifier>
  <hjid>10746</hjid>
  <measurementUnitQualifierCode>E</measurementUnitQualifierCode>
</measurementUnitQualifier>
```

# How to test
1. Run the CDS importer
2. Run the following SQL statement:

![Screen Shot 2020-12-15 at 13 36 13](https://user-images.githubusercontent.com/1955084/102221897-a2335d80-3eda-11eb-89aa-35dbbd785d1d.png)

As you can see the CDS increments will always have the filename attached, and you can see now there is a record.