### PR TITLE
Adding the new quota rules for order_numbers 05*

### DIFF
--- a/app/models/quota_order_number.rb
+++ b/app/models/quota_order_number.rb
@@ -11,7 +11,7 @@ class QuotaOrderNumber < Sequel::Model
   end
 
   def quota_definition!
-    return nil if quota_order_number_id.starts_with?('094')
+    return nil if quota_order_number_id.starts_with?('094', '054')
 
     quota_definition(reload: true)
   end

--- a/app/validators/measure_validator.rb
+++ b/app/validators/measure_validator.rb
@@ -160,9 +160,9 @@ class MeasureValidator < TradeTariffBackend::Validator
       on: %i[create update],
       if: ->(record) {
         record.validity_start_date > Date.new(2007, 12, 31) &&
-          record.order_number.present? && record.ordernumber =~ /^09[012356789]/
+          record.ordernumber.present? && record.ordernumber =~ /^((09)|(05))[012356789]/
       } do
-    # Only quota order numbers managed by the first come first served principle are in scope; these order number are starting with '09'; except order numbers starting with '094'
+    # Only quota order numbers managed by the first come first served principle are in scope; these order number are starting with '09' or '05'; except order numbers starting with '094', '054'
     validates :validity_date_span, of: :order_number
   end
 end

--- a/spec/models/quota_order_number_spec.rb
+++ b/spec/models/quota_order_number_spec.rb
@@ -25,8 +25,18 @@ RSpec.describe QuotaOrderNumber do
       end
     end
 
-    context 'when handled by the RPA' do
+    context 'when handled by the RPA with start code 094*' do
       let(:quota_order_number) { described_class.new(quota_order_number_id: '094504') }
+
+      describe '#quota_definition!' do
+        it 'returns nil' do
+          expect(quota_order_number.quota_definition!).to eq(nil)
+        end
+      end
+    end
+
+    context 'when handled by the RPA with start code 054*' do
+      let(:quota_order_number) { described_class.new(quota_order_number_id: '054504') }
 
       describe '#quota_definition!' do
         it 'returns nil' do


### PR DESCRIPTION
# Context
Add new rules for licensed quotas:

The DIT team has opted to differentiate UK quotas
from EU quotas by using “05” at the start instead of “09”

The rule now is that any quota that starts with either “094”
or “054” is a licensed quota - any other is not licensed.

# Ticket
https://transformuk.atlassian.net/browse/HOTT-189

# How to test

## Non licensed quotas
```ruby
update measures_oplog set ordernumber='090922' where ordernumber='050922'
update quota_definitions_oplog set quota_order_number_id='090922' where quota_order_number_id='050922'
update quota_order_numbers_oplog set quota_order_number_id='090922' where quota_order_number_id='050922'

commodities/0702000099#import
```

## Licensed quotas
```ruby
update measures_oplog set ordernumber='054203' where measure_sid='3285062'

/commodities/0102295110
```