### PR TITLE
Default to the service currency and disable currency conversion

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,8 +68,9 @@ group :development do
 end
 
 group :development, :test do
-  gem "dotenv-rails", ">= 2.7.6"
-  gem "pry", "~> 0.13"
+  gem "dotenv-rails"
+  gem "pry-rails"
+  gem "pry-byebug"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -983,6 +983,7 @@ GEM
     bootsnap (1.4.6)
       msgpack (~> 1.0)
     builder (3.2.4)
+    byebug (11.1.3)
     coderay (1.1.3)
     combine_pdf (1.0.16)
       ruby-rc4 (>= 0.1.5)
@@ -1115,6 +1116,11 @@ GEM
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    pry-byebug (3.9.0)
+      byebug (~> 11.0)
+      pry (~> 0.13.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     public_suffix (4.0.6)
     puma (5.0.4)
       nio4r (~> 2.0)
@@ -1307,7 +1313,7 @@ DEPENDENCIES
   combine_pdf
   curb (~> 0.9)
   database_cleaner
-  dotenv-rails (>= 2.7.6)
+  dotenv-rails
   elasticsearch (= 7.9.0)
   elasticsearch-extensions (= 0.0.31)
   factory_bot_rails
@@ -1327,7 +1333,8 @@ DEPENDENCIES
   ox (>= 2.8.1)
   pg (~> 1.1, >= 1.1.3)
   plek (~> 1.11)
-  pry (~> 0.13)
+  pry-byebug
+  pry-rails
   puma (~> 5.0.4)
   rabl (~> 0.14)
   rack-timeout (~> 0.4)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,6 @@ class ApplicationController < ActionController::Base
   respond_to :json, :html
 
   before_action :sample_requests_for_scout
-  before_action :configure_currency
   around_action :configure_time_machine
 
   unless Rails.application.config.consider_all_requests_local
@@ -60,10 +59,6 @@ class ApplicationController < ActionController::Base
     TimeMachine.at(actual_date) do
       yield
     end
-  end
-
-  def configure_currency
-    TradeTariffBackend.currency = params[:currency]&.to_s&.upcase
   end
 
   def sample_requests_for_scout

--- a/app/formatters/duty_expression_formatter.rb
+++ b/app/formatters/duty_expression_formatter.rb
@@ -19,18 +19,18 @@ class DutyExpressionFormatter
       measurement_unit_qualifier = opts[:measurement_unit_qualifier]
       measurement_unit_abbreviation = measurement_unit.try :abbreviation,
                                                            measurement_unit_qualifier: measurement_unit_qualifier
-      currency = opts[:currency] || TradeTariffBackend.currency
-      excise = opts[:excise]
+      if TradeTariffBackend.currency_conversion_enabled?
+        currency = opts[:currency] || TradeTariffBackend.currency
+        excise = opts[:excise]
 
-      old_duty_amount = duty_amount
-      old_monetary_unit = monetary_unit
-      if !excise && duty_amount.present? && currency.present? && monetary_unit.present? && monetary_unit != currency
-        period = MonetaryExchangePeriod.actual.last(parent_monetary_unit_code: 'EUR')
-        if period.present?
-          rate = MonetaryExchangeRate.last(monetary_exchange_period_sid: period.monetary_exchange_period_sid, child_monetary_unit_code: monetary_unit == 'EUR' ? currency : monetary_unit)
-          if rate.present?
-            duty_amount = (monetary_unit == 'EUR' ? (rate.exchange_rate * duty_amount.to_d).to_f : (duty_amount.to_d / rate.exchange_rate).to_f).round(2)
-            monetary_unit = currency
+        if !excise && duty_amount.present? && currency.present? && monetary_unit.present? && monetary_unit != currency
+          period = MonetaryExchangePeriod.actual.last(parent_monetary_unit_code: 'EUR')
+          if period.present?
+            rate = MonetaryExchangeRate.last(monetary_exchange_period_sid: period.monetary_exchange_period_sid, child_monetary_unit_code: monetary_unit == 'EUR' ? currency : monetary_unit)
+            if rate.present?
+              duty_amount = (monetary_unit == 'EUR' ? (rate.exchange_rate * duty_amount.to_d).to_f : (duty_amount.to_d / rate.exchange_rate).to_f).round(2)
+              monetary_unit = currency
+            end
           end
         end
       end

--- a/app/formatters/duty_expression_formatter.rb
+++ b/app/formatters/duty_expression_formatter.rb
@@ -57,7 +57,7 @@ class DutyExpressionFormatter
         end
         if duty_amount.present?
           output << if opts[:formatted]
-                      "<span title='#{old_duty_amount} #{old_monetary_unit}'>#{prettify(duty_amount)}</span>"
+                      html_formatted_duty_expression(duty_amount)
                     else
                       prettify(duty_amount).to_s
                     end
@@ -77,7 +77,7 @@ class DutyExpressionFormatter
       else
         if duty_amount.present?
           output << if opts[:formatted]
-                      "<span title='#{old_duty_amount} #{old_monetary_unit}'>#{prettify(duty_amount)}</span>"
+                      html_formatted_duty_expression(duty_amount)
                     else
                       prettify(duty_amount).to_s
                     end
@@ -101,6 +101,10 @@ class DutyExpressionFormatter
         end
       end
       output.join(" ").html_safe
+    end
+
+    def html_formatted_duty_expression(duty_amount)
+      "<span>#{prettify(duty_amount)}</span>"
     end
   end
 end

--- a/app/formatters/duty_expression_formatter.rb
+++ b/app/formatters/duty_expression_formatter.rb
@@ -103,6 +103,8 @@ class DutyExpressionFormatter
       output.join(" ").html_safe
     end
 
+    private
+
     def html_formatted_duty_expression(duty_amount)
       "<span>#{prettify(duty_amount)}</span>"
     end

--- a/app/formatters/requirement_duty_expression_formatter.rb
+++ b/app/formatters/requirement_duty_expression_formatter.rb
@@ -16,17 +16,21 @@ class RequirementDutyExpressionFormatter
       measurement_unit_qualifier = opts[:formatted_measurement_unit_qualifier]
       measurement_unit_abbreviation = measurement_unit.try :abbreviation,
                                                            measurement_unit_qualifier: measurement_unit_qualifier
-      currency = opts[:currency] || TradeTariffBackend.currency
 
-      old_duty_amount = duty_amount
-      old_monetary_unit = monetary_unit
-      if duty_amount.present? && currency.present? && monetary_unit.present? && monetary_unit != currency
-        period = MonetaryExchangePeriod.actual.last(parent_monetary_unit_code: 'EUR')
-        if period.present?
-          rate = MonetaryExchangeRate.last(monetary_exchange_period_sid: period.monetary_exchange_period_sid, child_monetary_unit_code: monetary_unit == 'EUR' ? currency : monetary_unit)
-          if rate.present?
-            duty_amount = (monetary_unit == 'EUR' ? (rate.exchange_rate * duty_amount.to_d).to_f : (duty_amount.to_d / rate.exchange_rate).to_f).round(2)
-            monetary_unit = currency
+      if TradeTariffBackend.currency_conversion_enabled?
+        currency = opts[:currency] || TradeTariffBackend.currency
+
+        old_duty_amount = duty_amount
+        old_monetary_unit = monetary_unit
+
+        if duty_amount.present? && currency.present? && monetary_unit.present? && monetary_unit != currency
+          period = MonetaryExchangePeriod.actual.last(parent_monetary_unit_code: 'EUR')
+          if period.present?
+            rate = MonetaryExchangeRate.last(monetary_exchange_period_sid: period.monetary_exchange_period_sid, child_monetary_unit_code: monetary_unit == 'EUR' ? currency : monetary_unit)
+            if rate.present?
+              duty_amount = (monetary_unit == 'EUR' ? (rate.exchange_rate * duty_amount.to_d).to_f : (duty_amount.to_d / rate.exchange_rate).to_f).round(2)
+              monetary_unit = currency
+            end
           end
         end
       end
@@ -35,7 +39,7 @@ class RequirementDutyExpressionFormatter
 
       if duty_amount.present?
         output << if opts[:formatted]
-                    "<span title='#{old_duty_amount} #{old_monetary_unit}'>#{prettify(duty_amount)}</span>"
+                    "<span>#{prettify(duty_amount)}</span>"
                   else
                     prettify(duty_amount).to_s
                   end

--- a/lib/trade_tariff_backend.rb
+++ b/lib/trade_tariff_backend.rb
@@ -36,7 +36,7 @@ module TradeTariffBackend
     end
 
     def use_cds?
-      ENV['CDS'] == 'true' && uk?
+      ENV['CDS'] == 'true'
     end
 
     def uk?

--- a/lib/trade_tariff_backend.rb
+++ b/lib/trade_tariff_backend.rb
@@ -16,7 +16,6 @@ module TradeTariffBackend
       'xi' => 'EUR'
     }.freeze
 
-
     def configure
       yield self
     end

--- a/lib/trade_tariff_backend.rb
+++ b/lib/trade_tariff_backend.rb
@@ -11,6 +11,12 @@ module TradeTariffBackend
   autoload :Validator,       'trade_tariff_backend/validator'
 
   class << self
+    SERVICE_CURRENCIES = {
+      'uk' => 'GBP',
+      'xi' => 'EUR'
+    }.freeze
+
+
     def configure
       yield self
     end
@@ -66,11 +72,6 @@ module TradeTariffBackend
     def production?
       ENV["GOVUK_APP_DOMAIN"] == "tariff-backend-production.cloudapps.digital"
     end
-
-    SERVICE_CURRENCIES = {
-      'uk' => 'GBP',
-      'xi' => 'EUR'
-    }.freeze
 
     def currency
       SERVICE_CURRENCIES.fetch(service, 'GBP')

--- a/lib/trade_tariff_backend.rb
+++ b/lib/trade_tariff_backend.rb
@@ -36,7 +36,15 @@ module TradeTariffBackend
     end
 
     def use_cds?
-      ENV['CDS'] == 'true'
+      ENV['CDS'] == 'true' && uk?
+    end
+
+    def uk?
+      service == 'uk'
+    end
+
+    def xi?
+      service == 'xi'
     end
 
     def platform
@@ -59,22 +67,13 @@ module TradeTariffBackend
       ENV["GOVUK_APP_DOMAIN"] == "tariff-backend-production.cloudapps.digital"
     end
 
-    THREAD_CURRENCY_KEY = :currency
-
-    def currency=(currency)
-      Thread.current[THREAD_CURRENCY_KEY] = (currency || currency_default)
-    end
+    SERVICE_CURRENCIES = {
+      'uk' => 'GBP',
+      'xi' => 'EUR'
+    }.freeze
 
     def currency
-      Thread.current[THREAD_CURRENCY_KEY] ||currency_default
-    end
-
-    def currency_default_gbp?
-      ENV.fetch('CURRENCY_GBP', 'false').to_s.downcase == 'true'
-    end
-  
-    def currency_default
-      currency_default_gbp? ? "GBP" : "EUR"
+      SERVICE_CURRENCIES.fetch(service, 'GBP')
     end
 
     def data_migration_path

--- a/lib/trade_tariff_backend.rb
+++ b/lib/trade_tariff_backend.rb
@@ -76,6 +76,10 @@ module TradeTariffBackend
       SERVICE_CURRENCIES.fetch(service, 'GBP')
     end
 
+    def currency_conversion_enabled?
+      ENV.fetch('CURRENCY_CONVERSION_ENABLED', 'false') == 'true'
+    end
+
     def data_migration_path
       File.join(Rails.root, 'db', 'data_migrations')
     end

--- a/spec/formatters/duty_expression_formatter_spec.rb
+++ b/spec/formatters/duty_expression_formatter_spec.rb
@@ -15,6 +15,11 @@ describe DutyExpressionFormatter do
     let!(:measurement_unit_qualifier) {
       create(:measurement_unit_qualifier, measurement_unit_qualifier_code: measurement_unit_abbreviation.measurement_unit_qualifier)
     }
+    let(:currency_conversion_enabled) { true }
+
+    before do
+      allow(TradeTariffBackend).to receive(:currency_conversion_enabled?).and_return(currency_conversion_enabled)
+    end
 
     context 'for excise measure' do
       it 'does not fetch exchange rates' do
@@ -100,6 +105,22 @@ describe DutyExpressionFormatter do
                                            duty_expression_description: 'abc',
                                            monetary_unit: 'EUR')
           ).to match /EUR/
+        end
+
+        context 'when currency conversion is disabled' do
+          let(:currency_conversion_enabled) { false }
+
+          it 'does not check the currency' do
+            allow(TradeTariffBackend).to receive(:currency)
+
+            described_class.format(
+              duty_expression_id: '15',
+              duty_expression_description: 'abc',
+              monetary_unit: 'EUR'
+            )
+
+            expect(TradeTariffBackend).not_to have_received(:currency)
+          end
         end
       end
 

--- a/spec/formatters/duty_expression_formatter_spec.rb
+++ b/spec/formatters/duty_expression_formatter_spec.rb
@@ -142,8 +142,7 @@ describe DutyExpressionFormatter do
     context 'for all other duty expression types' do
       context 'duty amount present' do
         it 'result includes duty amount' do
-          expect(
-            described_class.format(duty_expression_id: '66',
+          expect( described_class.format(duty_expression_id: '66',
                                            duty_expression_description: 'abc',
                                            duty_amount: '55')
           ).to match /55/
@@ -180,12 +179,30 @@ describe DutyExpressionFormatter do
       end
 
       context 'monetary unit present' do
-        it 'result includes monetary unit' do
-          expect(
-            described_class.format(duty_expression_id: '66',
-                                           duty_expression_description: 'abc',
-                                           monetary_unit: 'EUR')
-          ).to match /EUR/
+        let(:options) do
+          {
+            duty_amount: 0.52,
+            duty_expression_id: '66',
+            duty_expression_description: 'abc',
+            monetary_unit: 'EUR',
+            formatted: formatted
+          }
+        end
+
+        context 'when formatted is `true`' do
+          let(:formatted) { true }
+
+          it 'result includes monetary unit' do
+            expect(described_class.format(options)).to eq('<span>0.52</span> EUR')
+          end
+        end
+
+        context 'when not formatted is `false`' do
+          let(:formatted) { false }
+
+          it 'result includes monetary unit' do
+            expect(described_class.format(options)).to eq('0.52 EUR')
+          end
         end
       end
 

--- a/spec/formatters/requirement_duty_expression_formatter_spec.rb
+++ b/spec/formatters/requirement_duty_expression_formatter_spec.rb
@@ -37,13 +37,35 @@ describe RequirementDutyExpressionFormatter do
     end
 
     context 'monetary unit and measurement unit are present' do
-      subject {
-        described_class.format(monetary_unit: 'EUR',
-                                                  measurement_unit: measurement_unit)
-      }
+      subject do
+        described_class.format(
+          duty_amount: 3.50,
+          monetary_unit: 'EUR',
+          measurement_unit: measurement_unit,
+          formatted: formatted
+        )
+      end
+
+      let(:formatted) { false }
+
+      it 'does not check the currency' do
+        allow(TradeTariffBackend).to receive(:currency)
+
+        subject
+
+        expect(TradeTariffBackend).not_to have_received(:currency)
+      end
 
       it 'properly formats result' do
-        expect(subject).to match /EUR \/ #{measurement_unit.description}/
+        expect(subject).to eq("3.50 EUR / #{measurement_unit.description}")
+      end
+
+      context 'when formatted in html' do
+        let(:formatted) { true }
+
+        it 'properly formats result' do
+          expect(subject).to eq("<span>3.50</span> EUR / <abbr title='#{measurement_unit.description}'>#{measurement_unit.description}</abbr>")
+        end
       end
     end
 

--- a/spec/models/measure_condition_spec.rb
+++ b/spec/models/measure_condition_spec.rb
@@ -150,7 +150,7 @@ describe MeasureCondition do
       }
 
       it 'returns rendered requirement duty expression' do
-        expect(measure_condition.requirement).to eq "<span title='108.56 FOO'>108.56</span> FOO / <abbr title='BAR'>BAR</abbr>"
+        expect(measure_condition.requirement).to eq "<span>108.56</span> FOO / <abbr title='BAR'>BAR</abbr>"
       end
     end
   end

--- a/spec/unit/trade_tariff_backend_spec.rb
+++ b/spec/unit/trade_tariff_backend_spec.rb
@@ -37,4 +37,34 @@ describe TradeTariffBackend do
       end
     end
   end
+
+  describe '.currency' do
+    before do
+      allow(described_class).to receive(:service).and_return(choice)
+    end
+
+    context 'when the service is xi' do
+      let(:choice) { 'xi' }
+
+      it 'returns the correct currency' do
+        expect(described_class.currency).to eq('EUR')
+      end
+    end
+
+    context 'when the service is uk' do
+      let(:choice) { 'uk' }
+
+      it 'returns the correct currency' do
+        expect(described_class.currency).to eq('GBP')
+      end
+    end
+
+    context 'when the service is not set' do
+      let(:choice) { nil }
+
+      it 'returns the correct currency' do
+        expect(described_class.currency).to eq('GBP')
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-174

### What

Forces default currency depending on the service and puts converting currencies behind a switch that is turned off by default.

**If currency conversion is turned on:**

When the service is `uk` we show rates in `GBP`
When the service is `xi` we show rates in `EUR`
When the service is not set we show rates in `GBP`

Duty amounts and currencies come from measure components and measure conditions. They are formatted (really converted and formatted) using the DutyExpressionFormatter and RequirementDutyExpressionFormatter modules.

- [x] Control currency based on service
- [x] Disable currency conversion by default
- [x] Fix pry config
- [x] Remove from currency from span

### Why

This is a requirement for when we roll out these two new services.

### AC

- [x] Depending on the service prefix in the frontend, we get either EUR (for xi), GBP (for uk and uk-old) shown
- [x] `SERVICE` flag is set in all apps in all spaces
- [x] Conversion is not done in either the measure condition requirement or the duty expressions coming from the measure components