### PR TITLE
Remove reference to information legal text

### DIFF
--- a/app/serializers/api/v2/measures/measure_legal_act_serializer.rb
+++ b/app/serializers/api/v2/measures/measure_legal_act_serializer.rb
@@ -11,10 +11,6 @@ module Api
         attributes :validity_start_date, :validity_end_date, :officialjournal_number,
                    :officialjournal_page
 
-        attribute :information_text do |regulation|
-          regulation&.information_text&.gsub(0xA0.chr('UTF-8'), '|')
-        end
-
         attribute :published_date do |regulation|
           regulation.try(:published_date)
         end


### PR DESCRIPTION
### What

We're seeing issues in development after pulling in a change by BZ https://sentry.io/organizations/engine-le/issues/2115101196/?project=5557005&query=is%3Aunresolved.

This issue was introduced and not tested here: https://github.com/bitzesty/trade-tariff-backend/commit/d4900c8cdd13cd13822b5a1db4cabbcddcfbcf0b

And then also not fixed here:  
https://github.com/bitzesty/trade-tariff-backend/commit/d4900c8cdd13cd13822b5a1db4cabbcddcfbcf0b

We are currently hiding legal text information in the frontend which drives this serializer and so can remove this and fix legal texts later as part of a wider review

### Why

Fixes issues with loading commodities in v2

### A/C

- [x] Dev commodities that were broken are now fixed https://dev.trade-tariff.service.gov.uk/uk/commodities/4403410000#import