### PR TITLE
Remove references to cds-test

### DIFF
--- a/app/workers/rollback_worker.rb
+++ b/app/workers/rollback_worker.rb
@@ -4,7 +4,7 @@ class RollbackWorker
   sidekiq_options queue: :rollbacks, retry: false
 
   def perform(date, redownload = false)
-    if PaasConfig.space.to_s == 'cds-test'
+    if TradeTariffBackend.use_cds?
       TariffSynchronizer.rollback_cds(date, redownload)
     else
       TariffSynchronizer.rollback(date, redownload)

--- a/spec/workers/rollback_worker_spec.rb
+++ b/spec/workers/rollback_worker_spec.rb
@@ -20,9 +20,9 @@ describe RollbackWorker, type: :worker do
       end
     end
 
-    context "for cds-test env" do
+    context "for cds env" do
       before do
-        allow(PaasConfig).to receive(:space).and_return("cds-test")
+        allow(TradeTariffBackend).to receive(:use_cds?).and_return(true)
       end
 
       it "invokes rollback_cds" do

--- a/spec/workers/updates_synchronizer_worker_spec.rb
+++ b/spec/workers/updates_synchronizer_worker_spec.rb
@@ -24,7 +24,7 @@ describe UpdatesSynchronizerWorker, type: :worker do
       end
     end
 
-    context "for cds-test env" do
+    context "for cds env" do
       before do
         allow(TradeTariffBackend).to receive(:use_cds?).and_return(true)
       end


### PR DESCRIPTION
### What

- [x] Force all CDS importer checks to be under the `use_cds?` method
- [x] Removes dead references to cds-test

### Why

When we're running with CDS=true in the importers we need to make sure
that we're not referencing the VCAP space and instead using the CDS flag since these spaces soon won't exist