### PR TITLE
Upgrade scout_apm gem 2.6.9 -> 4.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1103,7 +1103,7 @@ GEM
       omniauth (~> 1.2)
     ox (2.13.4)
     parallel (1.19.2)
-    parser (2.7.2.0)
+    parser (3.0.0.0)
       ast (~> 2.4.1)
     pdf-core (0.8.1)
     pg (1.2.3)
@@ -1239,7 +1239,7 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    scout_apm (2.6.9)
+    scout_apm (4.0.0)
       parser
     scss_lint (0.59.0)
       sass (~> 3.5, >= 3.5.5)


### PR DESCRIPTION
# Context
The upgrade is necessary so we can enable the
background workers monitoring within Scout.