### PR TITLE
Enable deploys to staging from non-master branches

### DIFF
--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -2,7 +2,6 @@ name: "Staging deployment"
 on: [workflow_dispatch]
 jobs:
   deploy_staging:
-    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
### What

Enable deploying any branch to staging

### Why

development does not have a scout apm integration (saving money) and we need validate rolling out a newer version of the scout apm gem