### PR TITLE
Support docker-compose for local postgres

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -6,10 +6,12 @@ default: &default
 development:
   <<: *default
   database: tariff_development
+  host: localhost
 
 test:
   <<: *default
   database: tariff_test
+  host: localhost
 
 production:
   <<: *default


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

When you install postgres using a *.{deb,app} file you end up getting
the relevant configuration files on your machine which tell the app to
use postgres over a local socket file - the default. When using
docker-compose to spin up postgres comms go via localhost:5432.

This change makes the current app work with app and docker-compose installs of postgres
with no effect on current installs

### Why?

I am doing this because:

- We want to make the app run without changes for people that prefer to use docker and not clutter their machines
