### PR TITLE
Enables pdf worker

### DIFF
--- a/app/workers/run_chapter_pdf_worker.rb
+++ b/app/workers/run_chapter_pdf_worker.rb
@@ -6,27 +6,27 @@ class RunChapterPdfWorker
   sidekiq_options retry: 2
 
   def perform(currencies = ['EUR'])
-    currencies.each do |currency|
-      batch = Sidekiq::Batch.new
-      batch.description = "Produces PDFs for all chapters (in #{currency})"
-      chapter_ids = Section.all.map(&:chapters).flatten.map(&:goods_nomenclature_sid)
-      # chapter_ids = %w[47137 32338 54748] # <- short chapters
-      if currency === 'EUR'
-        ENV["MX_RATE_EUR_EUR"] = '1.0'
-      else
-        ENV["MX_RATE_EUR_#{currency}"] ||= MonetaryExchangeRate.latest(currency).to_s
+    currency = TradeTariffBackend.currency
+
+    batch = Sidekiq::Batch.new
+    batch.description = "Produces PDFs for all chapters (in #{currency})"
+    chapter_ids = Section.all.map(&:chapters).flatten.map(&:goods_nomenclature_sid)
+    # chapter_ids = %w[47137 32338 54748] # <- short chapters
+    if currency === 'EUR'
+      ENV["MX_RATE_EUR_EUR"] = '1.0'
+    else
+      ENV["MX_RATE_EUR_#{currency}"] ||= MonetaryExchangeRate.latest(currency).to_s
+    end
+    if chapter_ids.empty?
+      puts "Cancelled batch #{batch.bid}. No chapters were specified."
+    else
+      batch.on(:success, BatchCallback, bid: batch.bid, total: chapter_ids.size, start_time: Time.now.to_i, currency: currency)
+      batch.jobs do
+        GenerateCoverPdfWorker.perform_async(currency)
       end
-      if chapter_ids.empty?
-        puts "Cancelled batch #{batch.bid}. No chapters were specified."
-      else
-        batch.on(:success, BatchCallback, bid: batch.bid, total: chapter_ids.size, start_time: Time.now.to_i, currency: currency)
-        batch.jobs do
-          GenerateCoverPdfWorker.perform_async(currency)
-        end
-        batch.jobs do
-          chapter_ids.shuffle.each do |sid|
-            GenerateChapterPdfWorker.perform_async(sid, currency)
-          end
+      batch.jobs do
+        chapter_ids.shuffle.each do |sid|
+          GenerateChapterPdfWorker.perform_async(sid, currency)
         end
       end
     end

--- a/app/workers/run_chapter_pdf_worker.rb
+++ b/app/workers/run_chapter_pdf_worker.rb
@@ -5,18 +5,14 @@ class RunChapterPdfWorker
 
   sidekiq_options retry: 2
 
-  def perform(currencies = ['EUR'])
+  def perform
     currency = TradeTariffBackend.currency
 
     batch = Sidekiq::Batch.new
     batch.description = "Produces PDFs for all chapters (in #{currency})"
     chapter_ids = Section.all.map(&:chapters).flatten.map(&:goods_nomenclature_sid)
     # chapter_ids = %w[47137 32338 54748] # <- short chapters
-    if currency === 'EUR'
-      ENV["MX_RATE_EUR_EUR"] = '1.0'
-    else
-      ENV["MX_RATE_EUR_#{currency}"] ||= MonetaryExchangeRate.latest(currency).to_s
-    end
+
     if chapter_ids.empty?
       puts "Cancelled batch #{batch.bid}. No chapters were specified."
     else

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -33,7 +33,6 @@
   ReindexModelsWorker:
     cron: "0 1 * * *" # 01:00 every day
     description: "ReindexModelsWorker will run every day at 1am."
-  # RunChapterPdfWorker:
-  #   cron: "0 5 * * *" # 05:00 every day
-  #   description: "RunChapterPdfWorker produces the Tariff PDF."
-  #   args: [['EUR', 'GBP']]
+  RunChapterPdfWorker:
+    cron: "0 5 * * *" # 05:00 every day
+    description: "RunChapterPdfWorker produces the Tariff PDF."


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Enable PDF worker
- [x] Execute worker with currency of current service

### Why?

I am doing this because:

- We need to verify the behaviour of the pdf workers and want them enabled eventually