### PR TITLE
Stop deploying the old uk backend in dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
       fail-fast: false
       max-parallel: 3
       matrix:
-        service: ["tariff-backend-dev",  "tariff-uk-backend-dev",  "tariff-xi-backend-dev"]
+        service: ["tariff-uk-backend-dev",  "tariff-xi-backend-dev"]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Tidy old dev deploy

### Why?

I am doing this because:

- This app is going away