### PR TITLE
Resume the XI data loader

### DIFF
--- a/app/workers/updates_synchronizer_worker.rb
+++ b/app/workers/updates_synchronizer_worker.rb
@@ -12,8 +12,7 @@ class UpdatesSynchronizerWorker
       TariffSynchronizer.download_cds
       logger.info "Applying..."
       TariffSynchronizer.apply_cds
-    else
-      # TODO: this can be removed when we switch to CDS data because we don't need to run CHIEF and TARIC updates.
+    elsif TradeTariffBackend.xi?
       TariffSynchronizer.download
       logger.info "Applying..."
       TariffSynchronizer.apply

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -18,9 +18,9 @@
   #
   # Online converter: https://crontab.guru/#0_22_*_*_*
   #
-  # UpdatesSynchronizerWorker:
-  #   cron: "0 22 * * *" # 10 PM every day
-  #   description: "UpdatesSynchronizerWorker will run every day at 10pm."
+  UpdatesSynchronizerWorker:
+    cron: "0 22 * * *" # 10 PM every day
+    description: "UpdatesSynchronizerWorker will run every day at 10pm."
   TaricSequenceCheckWorker:
     cron: "0 14 * * 6" # 14:00 every Saturday
     description: "TaricSequenceCheckWorker will run every Saturday at 14:00."

--- a/spec/workers/updates_synchronizer_worker_spec.rb
+++ b/spec/workers/updates_synchronizer_worker_spec.rb
@@ -9,27 +9,39 @@ describe UpdatesSynchronizerWorker, type: :worker do
     allow(TariffSynchronizer).to receive(:apply_cds)
   end
 
-  describe "#perform" do
-    context "for all envs" do
+  describe '#perform' do
+    context 'when CDS flag is off' do
       before do
         allow(TradeTariffBackend).to receive(:use_cds?).and_return(false)
       end
 
-      it "invokes rollback" do
+      it 'invokes the apply/download for the XI service' do
+        allow(TradeTariffBackend).to receive(:xi?).and_return(true)
+
         expect(TariffSynchronizer).to receive(:download)
         expect(TariffSynchronizer).to receive(:apply)
         expect(TariffSynchronizer).not_to receive(:download_cds)
         expect(TariffSynchronizer).not_to receive(:apply_cds)
         described_class.new.perform
       end
+
+      it 'does not invoke any apply/download for the UK service' do
+        allow(TradeTariffBackend).to receive(:uk?).and_return(true)
+
+        expect(TariffSynchronizer).not_to receive(:download)
+        expect(TariffSynchronizer).not_to receive(:apply)
+        expect(TariffSynchronizer).not_to receive(:download_cds)
+        expect(TariffSynchronizer).not_to receive(:apply_cds)
+        described_class.new.perform
+      end
     end
 
-    context "for cds env" do
+    context 'when CDS flag is on' do
       before do
         allow(TradeTariffBackend).to receive(:use_cds?).and_return(true)
       end
 
-      it "invokes rollback_cds" do
+      it 'invokes rollback_cds' do
         expect(TariffSynchronizer).to receive(:download_cds)
         expect(TariffSynchronizer).to receive(:apply_cds)
         expect(TariffSynchronizer).not_to receive(:download)


### PR DESCRIPTION
### Jira link

HOTT-308

### What?

Scheduling back the XI importer as it's now safe to do so.
The UK importers will remain disabled until the CDS
data issue is fixed.

### Why?

- The XI data has a green light now.
- The UK data is still problematic because we need to fix the Geographical Areas issues.