### PR TITLE
Add required hjid field to the db, create the data importers and add the data transform step for CDS importer

### DIFF
--- a/app/services/geographical_area_memberships_import_service.rb
+++ b/app/services/geographical_area_memberships_import_service.rb
@@ -1,0 +1,45 @@
+require 'csv'
+
+class GeographicalAreaMembershipsImportService
+  attr_accessor :errors
+
+  def initialize
+    @errors = []
+  end
+
+  def import_hjids(filename)
+    CSV.foreach(filename, headers: true) do |row|
+      update_geographical_area(row)
+    end
+    
+  end
+
+  def import_hjids_stats
+    {
+      geographical_areas_total: GeographicalAreaMembership.count,
+      geographical_areas_with_hjid_total: GeographicalAreaMembership.exclude(hjid: nil).count,
+      errors: errors.count
+    }
+  end
+
+  private
+
+  def update_geographical_area(row)
+    geographical_area_membership = GeographicalAreaMembership[
+      geographical_area_sid: row[2].to_i,
+      geographical_area_group_sid: row[4].to_i,
+      validity_start_date: row[5]
+    ]
+
+    if geographical_area_membership.present?
+      geographical_area_membership.hjid = row[0].to_i
+      geographical_area_membership.geographical_area_hjid = row[1].to_i
+      geographical_area_membership.geographical_area_group_hjid = row[3].to_i
+      geographical_area_membership.save
+    else
+      print "Failed to find matching geographical area for geographical_area_sid: #{row[2]}, geographical_area_group_sid: #{row[4]}, validity_start_date: #{row[5]} \n"
+      errors << row
+    end
+  end
+end
+

--- a/app/services/geographical_areas_import_service.rb
+++ b/app/services/geographical_areas_import_service.rb
@@ -1,0 +1,38 @@
+require 'csv'
+
+class GeographicalAreasImportService
+  attr_accessor :errors
+
+  def initialize
+    @errors = []
+  end
+
+  def import_hjids(filename)
+    CSV.foreach(filename, headers: true) do |row|
+      update_geographical_area(row)
+    end
+    
+  end
+
+  def import_hjids_stats
+    {
+      geographical_areas_total: GeographicalArea.count,
+      geographical_areas_with_hjid_total: GeographicalArea.exclude(hjid: nil).count,
+      errors: errors.count
+    }
+  end
+
+  private
+
+  def update_geographical_area(row)
+    geographical_area = GeographicalArea[geographical_area_sid: row[1].to_i]
+    if geographical_area.present?
+      geographical_area.hjid = row[0].to_i
+      geographical_area.save
+    else
+      print "Failed to find matching geographical area for geographical_area_sid: #{row[1]}\n"
+      errors << row
+    end
+  end
+end
+

--- a/db/migrate/20210108162807_add_hjid_to_geographical_areas_oplog.rb
+++ b/db/migrate/20210108162807_add_hjid_to_geographical_areas_oplog.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table :geographical_areas_oplog do
+      add_column :hjid, Integer
+    end
+  end
+end

--- a/db/migrate/20210108163822_add_hjid_to_geographical_area_memberships_oplog.rb
+++ b/db/migrate/20210108163822_add_hjid_to_geographical_area_memberships_oplog.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table :geographical_area_memberships_oplog do
+      add_column :hjid, Integer
+    end
+  end
+end

--- a/db/migrate/20210108165416_add_hjid_to_geographical_areas_view.rb
+++ b/db/migrate/20210108165416_add_hjid_to_geographical_areas_view.rb
@@ -1,0 +1,27 @@
+Sequel.migration do
+  change do
+    run %Q{
+      DROP VIEW public.geographical_areas;
+    }
+
+    run %Q{
+      CREATE OR REPLACE VIEW public.geographical_areas AS
+        SELECT geographical_areas1.geographical_area_sid,
+        geographical_areas1.parent_geographical_area_group_sid,
+        geographical_areas1.validity_start_date,
+        geographical_areas1.validity_end_date,
+        geographical_areas1.geographical_code,
+        geographical_areas1.geographical_area_id,
+        geographical_areas1."national",
+        geographical_areas1.oid,
+        geographical_areas1.operation,
+        geographical_areas1.operation_date,
+        geographical_areas1.filename,
+        geographical_areas1.hjid
+      FROM geographical_areas_oplog geographical_areas1
+      WHERE (geographical_areas1.oid IN ( SELECT max(geographical_areas2.oid) AS max
+          FROM geographical_areas_oplog geographical_areas2
+          WHERE geographical_areas1.geographical_area_sid = geographical_areas2.geographical_area_sid)) AND geographical_areas1.operation::text <> 'D'::text;
+    }
+  end
+end

--- a/db/migrate/20210108170325_add_hjid_to_geographical_area_memberships_view.rb
+++ b/db/migrate/20210108170325_add_hjid_to_geographical_area_memberships_view.rb
@@ -1,0 +1,25 @@
+Sequel.migration do
+  change do
+    run %Q{
+      DROP VIEW public.geographical_area_memberships;
+    }
+
+    run %Q{
+      CREATE OR REPLACE VIEW public.geographical_area_memberships AS
+        SELECT geographical_area_memberships1.geographical_area_sid,
+        geographical_area_memberships1.geographical_area_group_sid,
+        geographical_area_memberships1.validity_start_date,
+        geographical_area_memberships1.validity_end_date,
+        geographical_area_memberships1."national",
+        geographical_area_memberships1.oid,
+        geographical_area_memberships1.operation,
+        geographical_area_memberships1.operation_date,
+        geographical_area_memberships1.filename,
+        geographical_area_memberships1.hjid
+      FROM geographical_area_memberships_oplog geographical_area_memberships1
+      WHERE (geographical_area_memberships1.oid IN ( SELECT max(geographical_area_memberships2.oid) AS max
+              FROM geographical_area_memberships_oplog geographical_area_memberships2
+              WHERE geographical_area_memberships1.geographical_area_sid = geographical_area_memberships2.geographical_area_sid AND geographical_area_memberships1.geographical_area_group_sid = geographical_area_memberships2.geographical_area_group_sid AND geographical_area_memberships1.validity_start_date = geographical_area_memberships2.validity_start_date)) AND geographical_area_memberships1.operation::text <> 'D'::text;
+    }
+  end
+end

--- a/db/migrate/20210112135615_add_new_fields_to_geographical_area_memberships_oplog.rb
+++ b/db/migrate/20210112135615_add_new_fields_to_geographical_area_memberships_oplog.rb
@@ -1,0 +1,8 @@
+Sequel.migration do
+  change do
+    alter_table :geographical_area_memberships_oplog do
+      add_column :geographical_area_hjid, Integer
+      add_column :geographical_area_group_hjid, Integer
+    end
+  end
+end

--- a/db/migrate/20210112160504_add_fields_to_geographical_area_memberships_view.rb
+++ b/db/migrate/20210112160504_add_fields_to_geographical_area_memberships_view.rb
@@ -1,0 +1,27 @@
+Sequel.migration do
+  change do
+    run %Q{
+      DROP VIEW public.geographical_area_memberships;
+    }
+
+    run %Q{
+      CREATE OR REPLACE VIEW public.geographical_area_memberships AS
+        SELECT geographical_area_memberships1.geographical_area_sid,
+        geographical_area_memberships1.geographical_area_group_sid,
+        geographical_area_memberships1.validity_start_date,
+        geographical_area_memberships1.validity_end_date,
+        geographical_area_memberships1."national",
+        geographical_area_memberships1.oid,
+        geographical_area_memberships1.operation,
+        geographical_area_memberships1.operation_date,
+        geographical_area_memberships1.filename,
+        geographical_area_memberships1.hjid,
+        geographical_area_memberships1.geographical_area_hjid,
+        geographical_area_memberships1.geographical_area_group_hjid
+      FROM geographical_area_memberships_oplog geographical_area_memberships1
+      WHERE (geographical_area_memberships1.oid IN ( SELECT max(geographical_area_memberships2.oid) AS max
+              FROM geographical_area_memberships_oplog geographical_area_memberships2
+              WHERE geographical_area_memberships1.geographical_area_sid = geographical_area_memberships2.geographical_area_sid AND geographical_area_memberships1.geographical_area_group_sid = geographical_area_memberships2.geographical_area_group_sid AND geographical_area_memberships1.validity_start_date = geographical_area_memberships2.validity_start_date)) AND geographical_area_memberships1.operation::text <> 'D'::text;
+    }
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2732,7 +2732,8 @@ CREATE TABLE public.geographical_areas_oplog (
     oid integer NOT NULL,
     operation character varying(1) DEFAULT 'C'::character varying,
     operation_date date,
-    filename text
+    filename text,
+    hjid integer
 );
 
 
@@ -10719,3 +10720,4 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20191022065944_update_file
 INSERT INTO "schema_migrations" ("filename") VALUES ('20200905141023_create_forum_links.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20201006192051_add_filename_to_oplog_tables.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20201006193537_fix_index_on_chapters_sections.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20210108162807_add_hjid_to_geographical_areas_oplog.rb');

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2674,7 +2674,9 @@ CREATE TABLE public.geographical_area_memberships_oplog (
     operation character varying(1) DEFAULT 'C'::character varying,
     operation_date date,
     filename text,
-    hjid integer
+    hjid integer,
+    geographical_area_hjid integer,
+    geographical_area_group_hjid integer
 );
 
 
@@ -2692,7 +2694,9 @@ CREATE VIEW public.geographical_area_memberships AS
     geographical_area_memberships1.operation,
     geographical_area_memberships1.operation_date,
     geographical_area_memberships1.filename,
-    geographical_area_memberships1.hjid
+    geographical_area_memberships1.hjid,
+    geographical_area_memberships1.geographical_area_hjid,
+    geographical_area_memberships1.geographical_area_group_hjid
    FROM public.geographical_area_memberships_oplog geographical_area_memberships1
   WHERE ((geographical_area_memberships1.oid IN ( SELECT max(geographical_area_memberships2.oid) AS max
            FROM public.geographical_area_memberships_oplog geographical_area_memberships2
@@ -10727,3 +10731,5 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20210108162807_add_hjid_to
 INSERT INTO "schema_migrations" ("filename") VALUES ('20210108163822_add_hjid_to_geographical_area_memberships_oplog.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20210108165416_add_hjid_to_geographical_areas_view.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20210108170325_add_hjid_to_geographical_area_memberships_view.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20210112135615_add_new_fields_to_geographical_area_memberships_oplog.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20210112160504_add_fields_to_geographical_area_memberships_view.rb');

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2691,7 +2691,8 @@ CREATE VIEW public.geographical_area_memberships AS
     geographical_area_memberships1.oid,
     geographical_area_memberships1.operation,
     geographical_area_memberships1.operation_date,
-    geographical_area_memberships1.filename
+    geographical_area_memberships1.filename,
+    geographical_area_memberships1.hjid
    FROM public.geographical_area_memberships_oplog geographical_area_memberships1
   WHERE ((geographical_area_memberships1.oid IN ( SELECT max(geographical_area_memberships2.oid) AS max
            FROM public.geographical_area_memberships_oplog geographical_area_memberships2
@@ -10722,5 +10723,6 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20191022065944_update_file
 INSERT INTO "schema_migrations" ("filename") VALUES ('20200905141023_create_forum_links.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20201006192051_add_filename_to_oplog_tables.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20201006193537_fix_index_on_chapters_sections.rb');INSERT INTO "schema_migrations" ("filename") VALUES ('20201006193537_fix_index_on_chapters_sections.rb');INSERT INTO "schema_migrations" ("filename") VALUES ('20210108162807_add_hjid_to_geographical_areas_oplog.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20210108163822_add_hjid_to_geographical_area_memberships_oplog.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20210108165416_add_hjid_to_geographical_areas_view.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20210108162807_add_hjid_to_geographical_areas_oplog.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20210108163822_add_hjid_to_geographical_area_memberships_oplog.rb');INSERT INTO "schema_migrations" ("filename") VALUES ('20210108165416_add_hjid_to_geographical_areas_view.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20210108170325_add_hjid_to_geographical_area_memberships_view.rb');

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2753,7 +2753,8 @@ CREATE VIEW public.geographical_areas AS
     geographical_areas1.oid,
     geographical_areas1.operation,
     geographical_areas1.operation_date,
-    geographical_areas1.filename
+    geographical_areas1.filename,
+    geographical_areas1.hjid
    FROM public.geographical_areas_oplog geographical_areas1
   WHERE ((geographical_areas1.oid IN ( SELECT max(geographical_areas2.oid) AS max
            FROM public.geographical_areas_oplog geographical_areas2
@@ -10720,5 +10721,6 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20180822124608_add_tariff_
 INSERT INTO "schema_migrations" ("filename") VALUES ('20191022065944_update_filename_size.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20200905141023_create_forum_links.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20201006192051_add_filename_to_oplog_tables.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20201006193537_fix_index_on_chapters_sections.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20210108162807_add_hjid_to_geographical_areas_oplog.rb');INSERT INTO "schema_migrations" ("filename") VALUES ('20210108163822_add_hjid_to_geographical_area_memberships_oplog.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20201006193537_fix_index_on_chapters_sections.rb');INSERT INTO "schema_migrations" ("filename") VALUES ('20201006193537_fix_index_on_chapters_sections.rb');INSERT INTO "schema_migrations" ("filename") VALUES ('20210108162807_add_hjid_to_geographical_areas_oplog.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20210108163822_add_hjid_to_geographical_area_memberships_oplog.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20210108165416_add_hjid_to_geographical_areas_view.rb');

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2673,7 +2673,8 @@ CREATE TABLE public.geographical_area_memberships_oplog (
     oid integer NOT NULL,
     operation character varying(1) DEFAULT 'C'::character varying,
     operation_date date,
-    filename text
+    filename text,
+    hjid integer
 );
 
 
@@ -10720,4 +10721,4 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20191022065944_update_file
 INSERT INTO "schema_migrations" ("filename") VALUES ('20200905141023_create_forum_links.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20201006192051_add_filename_to_oplog_tables.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20201006193537_fix_index_on_chapters_sections.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20210108162807_add_hjid_to_geographical_areas_oplog.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20210108162807_add_hjid_to_geographical_areas_oplog.rb');INSERT INTO "schema_migrations" ("filename") VALUES ('20210108163822_add_hjid_to_geographical_area_memberships_oplog.rb');

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -10722,7 +10722,8 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20180822124608_add_tariff_
 INSERT INTO "schema_migrations" ("filename") VALUES ('20191022065944_update_filename_size.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20200905141023_create_forum_links.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20201006192051_add_filename_to_oplog_tables.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20201006193537_fix_index_on_chapters_sections.rb');INSERT INTO "schema_migrations" ("filename") VALUES ('20201006193537_fix_index_on_chapters_sections.rb');INSERT INTO "schema_migrations" ("filename") VALUES ('20210108162807_add_hjid_to_geographical_areas_oplog.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20201006193537_fix_index_on_chapters_sections.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20210108162807_add_hjid_to_geographical_areas_oplog.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20210108163822_add_hjid_to_geographical_area_memberships_oplog.rb');INSERT INTO "schema_migrations" ("filename") VALUES ('20210108165416_add_hjid_to_geographical_areas_view.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20210108163822_add_hjid_to_geographical_area_memberships_oplog.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20210108165416_add_hjid_to_geographical_areas_view.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20210108170325_add_hjid_to_geographical_area_memberships_view.rb');

--- a/lib/cds_importer/entity_mapper.rb
+++ b/lib/cds_importer/entity_mapper.rb
@@ -20,9 +20,9 @@ class CdsImporter
       mappers = ALL_MAPPERS.select  { |m| m.mapping_root == key }
                            .sort_by { |m| m.mapping_path ? m.mapping_path.length : 0 }
 
-      transform!
-
       mappers.each do |mapper|
+        transform! if mapper == CdsImporter::EntityMapper::GeographicalAreaMembershipMapper
+
         instances = mapper.new(xml_node).parse
         instances.each do |i|
           if TariffSynchronizer.cds_logger_enabled
@@ -58,7 +58,7 @@ class CdsImporter
     end
 
     def transform!
-      return unless key == 'GeographicalArea' && xml_node.has_key?('geographicalAreaMembership')
+      return unless xml_node.has_key?('geographicalAreaMembership')
 
       mutate_geographical_area_membership_node!
     end
@@ -67,6 +67,7 @@ class CdsImporter
       convert_single_geo_area_member_to_array!
 
       xml_node['geographicalAreaMembership'] = xml_node['geographicalAreaMembership'].each_with_object([]) do |geographical_area_membership, array|
+
         next unless geographical_area_membership.has_key?('geographicalAreaGroupSid')
 
         geographical_area = GeographicalArea[hjid: geographical_area_membership['geographicalAreaGroupSid']]

--- a/lib/cds_importer/entity_mapper.rb
+++ b/lib/cds_importer/entity_mapper.rb
@@ -60,13 +60,13 @@ class CdsImporter
     def transform!
       return unless key == 'GeographicalArea' && xml_node.has_key?('geographicalAreaMembership')
 
-      mutateGeographicalAreaMembershipNode!
+      mutate_geographical_area_membership_node!
     end
 
-    def mutated_node
-      handleSingleMember!
+    def mutate_geographical_area_membership_node!
+      convert_single_geo_area_member_to_array!
 
-      xml_node['geographicalAreaMembership'].each_with_object([]) do |geographical_area_membership, array|
+      xml_node['geographicalAreaMembership'] = xml_node['geographicalAreaMembership'].each_with_object([]) do |geographical_area_membership, array|
         next unless geographical_area_membership.has_key?('geographicalAreaGroupSid')
 
         geographical_area = GeographicalArea[hjid: geographical_area_membership['geographicalAreaGroupSid']]
@@ -82,14 +82,10 @@ class CdsImporter
       xml_node['sid']
     end
 
-    def handleSingleMember!
+    def convert_single_geo_area_member_to_array!
       return if xml_node['geographicalAreaMembership'].kind_of?(Array)
 
-      xml_node['geographicalAreaMembership'] =[xml_node['geographicalAreaMembership']]
-    end
-
-    def mutateGeographicalAreaMembershipNode!
-      xml_node['geographicalAreaMembership'] = mutated_node
+      xml_node['geographicalAreaMembership'] = [xml_node['geographicalAreaMembership']]
     end
   end
 end

--- a/lib/cds_importer/entity_mapper/geographical_area_mapper.rb
+++ b/lib/cds_importer/entity_mapper/geographical_area_mapper.rb
@@ -6,6 +6,7 @@ class CdsImporter
       self.mapping_root = "GeographicalArea".freeze
 
       self.entity_mapping = base_mapping.merge(
+        "hjid" => :hjid,
         "sid" => :geographical_area_sid,
         "geographicalCode" => :geographical_code,
         "geographicalAreaId" => :geographical_area_id,

--- a/lib/cds_importer/entity_mapper/geographical_area_membership_mapper.rb
+++ b/lib/cds_importer/entity_mapper/geographical_area_membership_mapper.rb
@@ -8,8 +8,9 @@ class CdsImporter
       self.mapping_path = "geographicalAreaMembership".freeze
 
       self.entity_mapping = base_mapping.merge(
-        "sid" => :geographical_area_sid,
-        "#{mapping_path}.geographicalAreaGroupSid" => :geographical_area_group_sid
+        "#{mapping_path}.hjid" => :hjid,
+        "#{mapping_path}.geographicalAreaGroupSid" => :geographical_area_group_sid,
+        "#{mapping_path}.geographicalAreaSid" => :geographical_area_sid
       ).freeze
 
       self.entity_mapping_key_as_array = mapping_with_key_as_array.freeze

--- a/lib/tasks/data_import/import_hjid_to_geographical_area_memberships.rake
+++ b/lib/tasks/data_import/import_hjid_to_geographical_area_memberships.rake
@@ -1,0 +1,17 @@
+namespace :data_import do
+  # bin/rails "data_import:import_hjid_to_geographical_area_memberships[hjid_member_map.csv]"
+  desc 'Import hjid data from source file to geographical_area_memberships_oplog table'
+  task :import_hjid_to_geographical_area_memberships, [:filename] => [:environment] do |_task, args|
+    # This is a one off task, so it can be ran locally pointing against the target DB using CF conduit
+    unless (filename = args[:filename]).present?
+      print 'No source file provided'
+      exit(false)
+    end
+
+    print "Importing hjid data from #{filename}...\n"
+    importer = GeographicalAreaMembershipsImportService.new
+    importer.import_hjids(filename)
+
+    print "\nResults:\n#{importer.import_hjids_stats}"
+  end
+end

--- a/lib/tasks/data_import/import_hjid_to_geographical_areas.rake
+++ b/lib/tasks/data_import/import_hjid_to_geographical_areas.rake
@@ -1,0 +1,17 @@
+namespace :data_import do
+  # bin/rails "data_import:import_hjid_to_geographical_areas[hjid_to_sid_map.csv]"
+  desc 'Import hjid data from source file to geographical_areas_oplog table'
+  task :import_hjid_to_geographical_areas, [:filename] => [:environment] do |_task, args|
+    # This is a one off task, so it can be ran locally pointing against the target DB using CF conduit
+    unless (filename = args[:filename]).present?
+      print 'No source file provided'
+      exit(false)
+    end
+
+    print "Importing hjid data from #{filename}...\n"
+    importer = GeographicalAreasImportService.new
+    importer.import_hjids(filename)
+
+    print "\nResults:\n#{importer.import_hjids_stats}"
+  end
+end

--- a/spec/fixtures/files/hjid_member_map.csv
+++ b/spec/fixtures/files/hjid_member_map.csv
@@ -1,0 +1,3 @@
+"geographical_area_membership_hjid","geographical_area_hjid","geographical_area_sid","geographical_area_group_hjid","geographical_area_group_sid","validity_start_date"
+25654,23590,256,23501,114,2004-05-01T00:00:00
+25473,23575,317,23501,114,2007-01-01T00:00:00

--- a/spec/fixtures/files/hjid_to_sid_map.csv
+++ b/spec/fixtures/files/hjid_to_sid_map.csv
@@ -1,0 +1,3 @@
+"geographical_area_hjid","geographical_area_sid"
+23500,374
+23501,114

--- a/spec/integration/cds_importer/entity_mapper_spec.rb
+++ b/spec/integration/cds_importer/entity_mapper_spec.rb
@@ -21,7 +21,14 @@ describe CdsImporter::EntityMapper do
   let(:mapper) { described_class.new('AdditionalCode', xml_node) }
 
   before do
-    stub_const('CdsImporter::EntityMapper::ALL_MAPPERS', [CdsImporter::EntityMapper::AdditionalCodeMapper])
+    stub_const(
+      'CdsImporter::EntityMapper::ALL_MAPPERS',
+      [
+        CdsImporter::EntityMapper::AdditionalCodeMapper,
+        CdsImporter::EntityMapper::GeographicalAreaMapper,
+        CdsImporter::EntityMapper::GeographicalAreaMembershipMapper
+      ]
+    )
   end
 
   describe '#import' do

--- a/spec/integration/cds_importer/entity_mappers_spec.rb
+++ b/spec/integration/cds_importer/entity_mappers_spec.rb
@@ -1128,6 +1128,7 @@ describe CdsImporter::EntityMapper do
       'geographicalAreaMembership' => {
         'hjid' => '25864',
         'geographicalAreaGroupSid' => '461273',
+        'geographicalAreaSid' => '311',
         'validityStartDate' => '2008-01-01T00:00:00',
         'validityEndDate' => '2020-06-29T20:04:37',
         'metainfo' => {
@@ -1141,7 +1142,7 @@ describe CdsImporter::EntityMapper do
     entity = subject.parse[0]
     expect(entity).to be_a(GeographicalAreaMembership)
     expect(entity).to be_valid
-    expect(entity.geographical_area_sid.to_s).to eq(values['sid'])
+    expect(entity.geographical_area_sid.to_s).to eq(values['geographicalAreaMembership']['geographicalAreaSid'])
     expect(entity.geographical_area_group_sid.to_s).to eq(values['geographicalAreaMembership']['geographicalAreaGroupSid'])
     expect(entity.validity_start_date).to eq(values['geographicalAreaMembership']['validityStartDate'])
     expect(entity.validity_end_date).to eq(values['geographicalAreaMembership']['validityEndDate'])

--- a/spec/services/geographical_area_import_service_spec.rb
+++ b/spec/services/geographical_area_import_service_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe GeographicalAreasImportService do
+  subject(:importer) { described_class.new }
+
+  let(:hjid_mappings_file) { Rails.root.join('spec', 'fixtures', 'files', 'hjid_to_sid_map.csv').to_s }
+  
+  let!(:area) {
+    create(:geographical_area, geographical_area_sid: 374)
+  }
+
+  before do
+    create(:geographical_area)
+  end
+
+  describe '#import_hjids' do
+    it 'raises error if invalid filename' do
+      expect { importer.import_hjids('foo') }.to raise_exception
+    end
+
+    it 'does not raise error with valid filename' do
+      expect { importer.import_hjids(hjid_mappings_file) }.not_to raise_exception
+    end
+
+    it 'updates matching geographical areas' do
+      importer.import_hjids(hjid_mappings_file)
+      expect(area.reload).to have_attributes(hjid: 23500)
+    end
+  end
+
+  describe '#import_hjids_stats' do
+    before { importer.import_hjids(hjid_mappings_file) }
+
+    it 'reports statistics on completion' do
+      expect(importer.import_hjids_stats).to eq(
+        geographical_areas_total: 2,
+        geographical_areas_with_hjid_total: 1,
+        errors: 1
+      )
+    end
+  end
+end

--- a/spec/services/geographical_area_memberships_import_service_spec.rb
+++ b/spec/services/geographical_area_memberships_import_service_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe GeographicalAreaMembershipsImportService do
+  subject(:importer) { described_class.new }
+
+  let(:hjid_mappings_file) { Rails.root.join('spec', 'fixtures', 'files', 'hjid_member_map.csv').to_s }
+  
+  let!(:area) {
+    create(:geographical_area_membership, geographical_area_sid: 256,
+    geographical_area_group_sid: 114,
+    validity_start_date: '2004-05-01T00:00:00'
+    )
+  }
+
+  before do
+    create(:geographical_area_membership)
+  end
+
+  describe '#import_hjids' do
+    it 'raises error if invalid filename' do
+      expect { importer.import_hjids('foo') }.to raise_exception
+    end
+
+    it 'does not raise error with valid filename' do
+      expect { importer.import_hjids(hjid_mappings_file) }.not_to raise_exception
+    end
+
+    it 'updates matching geographical areas' do
+      importer.import_hjids(hjid_mappings_file)
+      expect(area.reload).to have_attributes(
+        hjid: 25654,
+        geographical_area_hjid: 23590,
+        geographical_area_group_hjid: 23501,
+      )
+    end
+  end
+
+  describe '#import_hjids_stats' do
+    before { importer.import_hjids(hjid_mappings_file) }
+
+    it 'reports statistics on completion' do
+      expect(importer.import_hjids_stats).to eq(
+        geographical_areas_total: 2,
+        geographical_areas_with_hjid_total: 1,
+        errors: 1
+      )
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

HOTT-274
HOTT-277
HOTT-335

### What?

I have:

- [x] added hjid fields to geographical_area_memberships_oplog and geographical_area_memberships view
- [x] added hjid field to geographical_area_oplog and geographical_areas view
- [x] added GeographicalAreasImportService that imports the hjid values from the mappings source file
- [x] added GeographicalAreaMembershipsImportService that imports the hjid values from the mappings source file
- [x] data transform step for the CDS importer that mutates the xml node so that:
       a) geographicalAreaGroupSid key points to sid value in the node,
       instead of the child member hjid (as it is now)
       b) it adds a new geographicalAreaSid key that points to the
       geographical_area_sid which is retrieved from Geographical Areas
       table, using the hjid as lookup key.

### Why?

Details behind the changes can be found at:

- https://transformuk.atlassian.net/browse/HOTT-274
- https://transformuk.atlassian.net/browse/HOTT-277
- https://transformuk.atlassian.net/browse/HOTT-335

### Deployment risks (optional)

- Contains migrations that drop and recreate some views
