### PR TITLE
Spike for logging to Data Dog

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,6 @@ gem 'bootsnap', require: false
 gem 'gds-sso', '~> 13', '>= 13.6.0'
 gem 'hashie', '~> 4'
 gem 'holidays'
-gem 'lograge', '>= 0.3.6'
 gem 'logstash-event'
 gem 'nokogiri', '>= 1.10.9'
 gem 'ox', '>= 2.8.1'
@@ -60,6 +59,11 @@ gem 'tilt'
 gem 'combine_pdf'
 gem 'sidekiq-batch'
 gem 'uktt', '~> 0.2.16', git: 'https://github.com/TransformCore/uktt.git'
+
+# Logging
+gem "lograge"
+gem "semantic_logger"
+gem 'rails_semantic_logger'
 
 group :development do
   gem 'foreman'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1149,6 +1149,10 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails_semantic_logger (4.4.6)
+      rack
+      railties (>= 3.2)
+      semantic_logger (~> 4.4)
     railties (6.0.3.4)
       actionpack (= 6.0.3.4)
       activesupport (= 6.0.3.4)
@@ -1236,6 +1240,8 @@ GEM
     safe_yaml (1.0.5)
     scout_apm (4.0.0)
       parser
+    semantic_logger (4.7.4)
+      concurrent-ruby (~> 1.0)
     sentry-raven (3.1.1)
       faraday (>= 1.0)
     sequel (5.22.0)
@@ -1319,7 +1325,7 @@ DEPENDENCIES
   json_expressions (~> 0.9.0)
   jsonapi-serializer
   letter_opener
-  lograge (>= 0.3.6)
+  lograge
   logstash-event
   nokogiri (>= 1.10.9)
   ox (>= 2.8.1)
@@ -1331,6 +1337,7 @@ DEPENDENCIES
   rabl (~> 0.14)
   rack-timeout (~> 0.4)
   rails (>= 6.0.3.4)
+  rails_semantic_logger
   redis-rails
   redlock (~> 1.1.0)
   responders (~> 3.0.0)
@@ -1339,6 +1346,7 @@ DEPENDENCIES
   rubocop-govuk
   rubyzip (>= 2.3.0)
   scout_apm
+  semantic_logger
   sentry-raven
   sequel (~> 5.22.0)
   sequel-rails (~> 1.0.0)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -47,4 +47,8 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
 
   config.log_level = :info
+
+  config.rails_semantic_logger.started    = true
+  config.rails_semantic_logger.processing = true
+  config.rails_semantic_logger.rendered   = true
 end

--- a/config/initializers/data_dog.rb
+++ b/config/initializers/data_dog.rb
@@ -1,0 +1,4 @@
+SemanticLogger.add_appender(
+  appender: :data_dog,
+  url:      'https://http-intake.logs.datadoghq.eu/v1/input'
+)

--- a/lib/semantic_logger/appender/data_dog.rb
+++ b/lib/semantic_logger/appender/data_dog.rb
@@ -1,0 +1,36 @@
+module SemanticLogger
+  module Appender
+    class DataDog < SemanticLogger::Appender::Http
+      attr_accessor :source_type, :index
+      
+      def initialize(token: nil,
+                     source_type: nil,
+                     index: nil,
+                     compress: true,
+                     **args,
+                     &block)
+
+        @source_type = source_type
+        @index       = index
+
+        super(compress: compress, **args, &block)
+
+        @header["DD-API-KEY"] = "#{ENV['DD_API_KEY']}"
+      end
+
+      def call(log, logger)
+        h                     = SemanticLogger::Formatters::Raw.new(time_format: :seconds).call(log, logger)
+        h.delete(:host)
+        message               = {
+          source: logger.application,
+          host:   logger.host + "Octavian Machine",
+          time:   h.delete(:time),
+          event:  h
+        }
+        message[:sourcetype]  = source_type if source_type
+        message[:index]       = index if index
+        message.to_json
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

Spike to see how to broadcast logs to an external API endpoint in our case DataDog

### Why?

Logs monitoring