### PR TITLE
Repush workflows following repo import

### DIFF
--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -1,4 +1,4 @@
-name: "Dev deployment"
+name: "Development Deployment"
 on: [workflow_dispatch]
 jobs:
   deploy_dev:

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -1,4 +1,4 @@
-name: "Production deployment"
+name: "Production Deployment"
 on: [workflow_dispatch]
 jobs:
   deploy_production:

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -1,4 +1,4 @@
-name: "Staging deployment"
+name: "Staging Deployment"
 on: [workflow_dispatch]
 jobs:
   deploy_staging:


### PR DESCRIPTION
### Jira link

n/A

### What?

I have added/removed/altered:

- [ ] Minor change, to repush workflows into new GH repo.

### Why?

I am doing this because:

- We re-imported the repos, and workflows need to be repushed to be picked up.
