### PR TITLE
Update the bti_url value for API V1 & V2

### DIFF
--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -129,6 +129,6 @@ class GoodsNomenclature < Sequel::Model
   end
 
   def bti_url
-    "http://ec.europa.eu/taxation_customs/dds2/ebti/ebti_consultation.jsp?Lang=en&nomenc=#{code}&Expand=true"
+    'https://www.gov.uk/guidance/check-what-youll-need-to-get-a-legally-binding-decision-on-a-commodity-code'
   end
 end

--- a/spec/models/goods_nomenclature_spec.rb
+++ b/spec/models/goods_nomenclature_spec.rb
@@ -417,10 +417,14 @@ describe GoodsNomenclature do
   end
 
   describe '#bti_url' do
-    let(:gono) { create(:goods_nomenclature, goods_nomenclature_item_id: '8056116321') }
+    let(:bti_url) {
+      'https://www.gov.uk/guidance/check-what-youll-need-to-get-a-legally-binding-decision-on-a-commodity-code'
+    }
+
+    let(:gono) { create(:goods_nomenclature) }
 
     it 'includes gono code' do
-      expect(gono.bti_url).to include(gono.code)
+      expect(gono.bti_url).to include(bti_url)
     end
   end
 


### PR DESCRIPTION
### Jira link

HOTT-268

### What?

Replace the existing dynamic bti_url value with a
static as a result of Brexit.

### Why?

The existing bti_url value no longer serves the purpose of post Brexit.