### PR TITLE
Remove reload: true from associations

### DIFF
--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -32,7 +32,7 @@ class GoodsNomenclature < Sequel::Model
   end
 
   def goods_nomenclature_indent
-    goods_nomenclature_indents(reload: true).first
+    goods_nomenclature_indents.first
   end
 
   many_to_many :goods_nomenclature_descriptions, join_table: :goods_nomenclature_description_periods,
@@ -45,7 +45,7 @@ class GoodsNomenclature < Sequel::Model
   end
 
   def goods_nomenclature_description
-    goods_nomenclature_descriptions(reload: true).first || NullGoodsNomenclature.new
+    goods_nomenclature_descriptions.first || NullGoodsNomenclature.new
   end
 
   many_to_many :footnotes, join_table: :footnote_association_goods_nomenclatures,
@@ -57,7 +57,7 @@ class GoodsNomenclature < Sequel::Model
   end
 
   def footnote
-    footnotes(reload: true).first
+    footnotes.first
   end
 
   one_to_one :national_measurement_unit_set, key: :cmdty_code,


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

- [x] Remove `reload: true` from association calls in `GoodsNomenclature` model

When you invoke an association with `reload: true` all of the benefits of cached results from an eager load are lost and the query is forcefully rerun. This is leading to around 90 queries for indents that are missing from `Commodity#ancestors` just for one commodity and is leading to a queue of postgres queries that are creating very long time outs for our api clients.

See the following commits for reference:

https://github.com/jeremyevans/sequel/commit/3d712213b4ac13ab69ddde0eae4
https://github.com/TransformCore/trade-tariff-backend/commit/a30b39485e86d82f7db434539f09ebb2acabd254

And the `Timemachine` plugin: 

https://github.com/TransformCore/trade-tariff-backend/blob/master/lib/sequel/plugins/time_machine.rb

From what I understand, this was put in place as a hack to get the Timemachine plugin functionality to work. From what I understand, cached resources that are loaded from a join and filter don't flip the switch to pull on the Timemachine `actual` method.

We wouldn't have noticed this behaviour as much if we hadn't dug into the massive slowness with the commodities controller which had had caching removed. I've since reinstated caching, here: https://github.com/TransformCore/trade-tariff-backend/pull/8.

### Why?

I am doing this because:

- We're having critically slow performance problems in the backend api

### Deployment risks (optional)

- This may break some Timemachine functionality when pulling out versions of indents and commodity descriptions (needs to be tested)
