### PR TITLE
[HOTT-359] Adds ancestors commodity spec for TimeMachine

### DIFF
--- a/spec/factories/goods_nomenclature_factory.rb
+++ b/spec/factories/goods_nomenclature_factory.rb
@@ -18,10 +18,14 @@ FactoryBot.define do
     validity_end_date   { nil }
 
     after(:build) do |gono, evaluator|
-      FactoryBot.create(:goods_nomenclature_indent, goods_nomenclature_sid: gono.goods_nomenclature_sid,
-                                                    validity_start_date: gono.validity_start_date,
-                                                    validity_end_date: gono.validity_end_date,
-                                                    number_indents: evaluator.indents)
+      FactoryBot.create(
+        :goods_nomenclature_indent, 
+        goods_nomenclature_sid: gono.goods_nomenclature_sid,
+        goods_nomenclature_item_id: gono.goods_nomenclature_item_id,
+        validity_start_date: gono.validity_start_date,
+        validity_end_date: gono.validity_end_date,
+        number_indents: evaluator.indents
+      )
     end
 
     trait :actual do


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-359

### What?

I have added/removed/altered:

- [x] Add a test to verify that the time machine works for nested indents
- [x] Fix broken factory hook in goods nomenclature parent factory

### Why?

We want to be sure that despite old commit comments from devs the reload behaviour which forces more inefficient querying is in fact not breaking the TimeMachine behaviour (see https://github.com/TransformCore/trade-tariff-backend/pull/10 for background).