### PR TITLE
Remove useless blocking condition

### DIFF
--- a/lib/tariff_synchronizer/file_service.rb
+++ b/lib/tariff_synchronizer/file_service.rb
@@ -40,7 +40,7 @@ module TariffSynchronizer
       end
 
       def file_as_stringio(tariff_update)
-        if Rails.env.production? && !TradeTariffBackend.use_cds?
+        if Rails.env.production?
           bucket.object(tariff_update.file_path).get.body
         else
           File.open(tariff_update.file_path)


### PR DESCRIPTION
### Jira link

HOTT-NA

### What?

Files should be looked for inside the S3 bucket on production.

### Why?

If we want to enable the CDS flag, without this change the importer would never check the S3 bucket, where the increments are being downloaded.
