### PR TITLE
Removes noisy output from scout in dev/test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ gem 'nokogiri', '>= 1.10.9'
 gem 'ox', '>= 2.8.1'
 gem 'plek', '~> 1.11'
 gem 'rack-timeout', '~> 0.4'
-gem 'scout_apm'
+gem 'scout_apm', require: false
 gem 'sentry-raven'
 
 # API related

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -62,6 +62,7 @@ class ApplicationController < ActionController::Base
   end
 
   def sample_requests_for_scout
+    return unless Rails.env.production?
     # Sample rate should range from 0-1:
     # * 0: captures no requests
     # * 0.75: captures 75% of requests

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,3 +1,5 @@
+require 'scout_apm'
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Removes startup log lines from scout when running locally in dev and test mode

### Why?

I am doing this because:

- This is noisy and distracting