### PR TITLE
Fix more test noise

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,31 +12,29 @@ AllCops:
     - 'vendor/**/*'
     - 'bin/**'
     - 'db/**/*'
-    - 'node_modules/**/*'
     - 'tmp/**/*'
-    - 'config/initializers/canonical_rails.rb'
     - 'config/puma.rb'
-    - 'spec/spec_helper.rb'
-Style/FrozenStringLiteralComment:
-  Enabled: false
-Style/Documentation:
+Layout/LineLength:
+  Max: 120
+Layout/AccessModifierIndentation:
   Enabled: false
 Metrics/AbcSize:
   Max: 20
-Layout/LineLength:
-  Max: 120
-Style/GuardClause:
-  MinBodyLength: 2
-Layout/AccessModifierIndentation:
-  Enabled: false
 Metrics/BlockLength:
   Enabled: false
 Metrics/ModuleLength:
   Enabled: false
-RSpec/DescribeClass:
-  Exclude:
-    - tasks/**/*.rb
 RSpec/ExampleLength:
   Enabled: false
+Rails/SaveBang:
+  Enabled: false
+Rails/FilePath:
+  Enabled: false
+Style/Documentation:
+  Enabled: false
+Style/FrozenStringLiteralComment:
+  Enabled: false
+Style/GuardClause:
+  MinBodyLength: 2
 Style/StringLiterals:
   EnforcedStyle: single_quotes

--- a/app/services/geographical_area_memberships_import_service.rb
+++ b/app/services/geographical_area_memberships_import_service.rb
@@ -11,14 +11,13 @@ class GeographicalAreaMembershipsImportService
     CSV.foreach(filename, headers: true) do |row|
       update_geographical_area(row)
     end
-    
   end
 
   def import_hjids_stats
     {
       geographical_areas_total: GeographicalAreaMembership.count,
       geographical_areas_with_hjid_total: GeographicalAreaMembership.exclude(hjid: nil).count,
-      errors: errors.count
+      errors: errors.count,
     }
   end
 
@@ -37,9 +36,8 @@ class GeographicalAreaMembershipsImportService
       geographical_area_membership.geographical_area_group_hjid = row[3].to_i
       geographical_area_membership.save
     else
-      print "Failed to find matching geographical area for geographical_area_sid: #{row[2]}, geographical_area_group_sid: #{row[4]}, validity_start_date: #{row[5]} \n"
+      Rails.logger.info("Failed to find matching geographical area membership for geographical_area_sid: #{row[2]}, geographical_area_group_sid: #{row[4]}, validity_start_date: #{row[5]} \n")
       errors << row
     end
   end
 end
-

--- a/app/services/geographical_areas_import_service.rb
+++ b/app/services/geographical_areas_import_service.rb
@@ -11,14 +11,13 @@ class GeographicalAreasImportService
     CSV.foreach(filename, headers: true) do |row|
       update_geographical_area(row)
     end
-    
   end
 
   def import_hjids_stats
     {
       geographical_areas_total: GeographicalArea.count,
       geographical_areas_with_hjid_total: GeographicalArea.exclude(hjid: nil).count,
-      errors: errors.count
+      errors: errors.count,
     }
   end
 
@@ -30,9 +29,8 @@ class GeographicalAreasImportService
       geographical_area.hjid = row[0].to_i
       geographical_area.save
     else
-      print "Failed to find matching geographical area for geographical_area_sid: #{row[1]}\n"
+      Rails.logger.info("Failed to find matching geographical area for geographical_area_sid: #{row[1]}\n")
       errors << row
     end
   end
 end
-

--- a/spec/services/geographical_area_import_service_spec.rb
+++ b/spec/services/geographical_area_import_service_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe GeographicalAreasImportService do
   subject(:importer) { described_class.new }
 
   let(:hjid_mappings_file) { Rails.root.join('spec', 'fixtures', 'files', 'hjid_to_sid_map.csv').to_s }
-  
-  let!(:area) {
+
+  let!(:area) do
     create(:geographical_area, geographical_area_sid: 374)
-  }
+  end
 
   before do
     create(:geographical_area)
@@ -15,16 +15,16 @@ RSpec.describe GeographicalAreasImportService do
 
   describe '#import_hjids' do
     it 'raises error if invalid filename' do
-      expect { importer.import_hjids('foo') }.to raise_exception
+      expect { importer.import_hjids('foo') }.to raise_error(Errno::ENOENT)
     end
 
     it 'does not raise error with valid filename' do
-      expect { importer.import_hjids(hjid_mappings_file) }.not_to raise_exception
+      expect { importer.import_hjids(hjid_mappings_file) }.not_to raise_error
     end
 
     it 'updates matching geographical areas' do
       importer.import_hjids(hjid_mappings_file)
-      expect(area.reload).to have_attributes(hjid: 23500)
+      expect(area.reload).to have_attributes(hjid: 23_500)
     end
   end
 
@@ -35,7 +35,7 @@ RSpec.describe GeographicalAreasImportService do
       expect(importer.import_hjids_stats).to eq(
         geographical_areas_total: 2,
         geographical_areas_with_hjid_total: 1,
-        errors: 1
+        errors: 1,
       )
     end
   end

--- a/spec/services/geographical_area_memberships_import_service_spec.rb
+++ b/spec/services/geographical_area_memberships_import_service_spec.rb
@@ -4,13 +4,12 @@ RSpec.describe GeographicalAreaMembershipsImportService do
   subject(:importer) { described_class.new }
 
   let(:hjid_mappings_file) { Rails.root.join('spec', 'fixtures', 'files', 'hjid_member_map.csv').to_s }
-  
-  let!(:area) {
+
+  let!(:area) do
     create(:geographical_area_membership, geographical_area_sid: 256,
-    geographical_area_group_sid: 114,
-    validity_start_date: '2004-05-01T00:00:00'
-    )
-  }
+                                          geographical_area_group_sid: 114,
+                                          validity_start_date: '2004-05-01T00:00:00')
+  end
 
   before do
     create(:geographical_area_membership)
@@ -18,19 +17,19 @@ RSpec.describe GeographicalAreaMembershipsImportService do
 
   describe '#import_hjids' do
     it 'raises error if invalid filename' do
-      expect { importer.import_hjids('foo') }.to raise_exception
+      expect { importer.import_hjids('foo') }.to raise_error(Errno::ENOENT)
     end
 
     it 'does not raise error with valid filename' do
-      expect { importer.import_hjids(hjid_mappings_file) }.not_to raise_exception
+      expect { importer.import_hjids(hjid_mappings_file) }.not_to raise_error
     end
 
     it 'updates matching geographical areas' do
       importer.import_hjids(hjid_mappings_file)
       expect(area.reload).to have_attributes(
-        hjid: 25654,
-        geographical_area_hjid: 23590,
-        geographical_area_group_hjid: 23501,
+        hjid: 25_654,
+        geographical_area_hjid: 23_590,
+        geographical_area_group_hjid: 23_501,
       )
     end
   end
@@ -42,7 +41,7 @@ RSpec.describe GeographicalAreaMembershipsImportService do
       expect(importer.import_hjids_stats).to eq(
         geographical_areas_total: 2,
         geographical_areas_with_hjid_total: 1,
-        errors: 1
+        errors: 1,
       )
     end
   end


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Group rubocop rules under their respective namespaces
- [x] Silence Rails/SaveBang errors which only relate to ActiveRecord
- [x] Silence noisy print output about importers missing geographical areas/memberships
- [x] Lint touched files generally
- [x] Silence noisy spec output about too generic exception testing

### Why?

I am doing this because:

- It's frustrating getting all of this distracting output in the tests