### PR TITLE
[HOTT-359] Adds Clearable concern to all Sequel::Model classes

### DIFF
--- a/app/models/concerns/clearable.rb
+++ b/app/models/concerns/clearable.rb
@@ -1,0 +1,13 @@
+module Clearable
+  extend ActiveSupport::Concern
+
+  included do
+    def self.clear_association_cache
+      association_reflections.map do |_association, association_state|
+        association_state[:cache] = {} if association_state[:cache].present?
+      end
+    end
+  end
+end
+
+Sequel::Model.include Clearable

--- a/spec/models/concerns/clearable_spec.rb
+++ b/spec/models/concerns/clearable_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe Clearable do
+  let(:mocked_model) do
+    Struct.new('Commodity') do
+      include Clearable
+
+      def self.association_reflections
+        @association_reflections ||=
+          begin
+            {
+              foo: { cache: { rows: ['some stuff'] } },
+              bar: { cache: {} },
+              baz: { flibble: { some_option: true } },
+
+            }
+          end
+      end
+    end
+  end
+
+  it 'clears association reflection caches' do
+    mocked_model.clear_association_cache
+
+    expect(mocked_model.association_reflections).to eq(
+      foo: { cache: {} },
+      bar: { cache: {} },
+      baz: { flibble: { some_option: true } },
+    )
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -55,5 +55,17 @@ RSpec.configure do |config|
     stub_codes_mapping_data
     Rails.cache.clear
     Sidekiq::Worker.clear_all
+
+    clearable_models = [
+      Certificate,
+      Chief::Tamf,
+      ExportRefundNomenclature,
+      Footnote,
+      GoodsNomenclature,
+      QuotaOrderNumber,
+    ]
+
+    clearable_models.map(&:clear_association_cache)
   end
 end
+


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-359

### What?

If a client of a model wants to clear the association cache there is
currently no public api that enables this behaviour.

We typically want to clear it in the tests because we run the same
queries (at least as they appear to Sequel) multiple times and expect different results to be returned from the cache.

This has been specifically highlighted in the tests around the
TimeMachine which doesn't update the cache key and therefore looks like
the same query.

We can get around this by adding behaviour to Sequel::Model classes
which clears the cache after every example and by making sure that we
don't have multiple TimeMachine expectations in the same example (see
subsequent commit for this change).

### Why?

I am doing this because:

- Our TimeMachine implementation doesn't affect the Sequel::Associations::AssociationReflection cache key and therefore looks like the same query.
- This is a precursor to proving/removing the reload behaviour from all files which has been added because of artefacts of our testing approach mixed with the TimeMachine idiosyncracies.