### PR TITLE
[HOTT-359] Remove misleading duplicate tests

### DIFF
--- a/spec/models/additional_code_spec.rb
+++ b/spec/models/additional_code_spec.rb
@@ -33,18 +33,6 @@ describe AdditionalCode do
         end
 
         it 'loads correct description respecting given time' do
-          TimeMachine.at(1.year.ago) do
-            expect(
-              additional_code.additional_code_description.pk,
-            ).to eq additional_code_description1.pk
-          end
-
-          TimeMachine.at(2.years.ago) do
-            expect(
-              additional_code.additional_code_description.pk,
-            ).to eq additional_code_description1.pk
-          end
-
           TimeMachine.at(4.years.ago) do
             expect(
               additional_code.reload.additional_code_description.pk,

--- a/spec/models/certificate_spec.rb
+++ b/spec/models/certificate_spec.rb
@@ -29,12 +29,6 @@ describe Certificate do
         end
 
         it 'loads correct description respecting given time' do
-          TimeMachine.at(1.year.ago) do
-            expect(
-              certificate.certificate_description.pk,
-            ).to eq certificate_description1.pk
-          end
-
           TimeMachine.at(4.years.ago) do
             expect(
               certificate.reload.certificate_description.pk,
@@ -58,17 +52,6 @@ describe Certificate do
         end
 
         it 'loads correct description respecting given time' do
-          TimeMachine.at(1.year.ago) do
-            expect(
-              described_class.where(certificate_type_code: certificate.certificate_type_code,
-                                    certificate_code: certificate.certificate_code)
-                        .eager(:certificate_descriptions)
-                        .all
-                        .first
-                        .certificate_description.pk,
-            ).to eq certificate_description1.pk
-          end
-
           TimeMachine.at(4.years.ago) do
             expect(
               described_class.where(certificate_type_code: certificate.certificate_type_code,
@@ -88,8 +71,5 @@ describe Certificate do
         let(:certificate_type_code) { Forgery(:basic).text(exactly: 1) }
       end
     end
-  end
-
-  describe 'validations' do
   end
 end

--- a/spec/models/export_refund_nomenclature_spec.rb
+++ b/spec/models/export_refund_nomenclature_spec.rb
@@ -27,12 +27,6 @@ describe ExportRefundNomenclature do
         end
 
         it 'loads correct indent respecting given time' do
-          TimeMachine.at(1.year.ago) do
-            expect(
-              export_refund_nomenclature.export_refund_nomenclature_indent.pk,
-            ).to eq export_refund_nomenclature_indent1.pk
-          end
-
           TimeMachine.at(4.years.ago) do
             expect(
               export_refund_nomenclature.reload.export_refund_nomenclature_indent.pk,
@@ -55,16 +49,6 @@ describe ExportRefundNomenclature do
         end
 
         it 'loads correct indent respecting given time' do
-          TimeMachine.at(1.year.ago) do
-            expect(
-              described_class.where(export_refund_nomenclature_sid: export_refund_nomenclature.export_refund_nomenclature_sid)
-                          .eager(:export_refund_nomenclature_indents)
-                          .all
-                          .first
-                          .export_refund_nomenclature_indent.pk,
-            ).to eq export_refund_nomenclature_indent1.pk
-          end
-
           TimeMachine.at(4.years.ago) do
             expect(
               described_class.where(export_refund_nomenclature_sid: export_refund_nomenclature.export_refund_nomenclature_sid)
@@ -103,12 +87,6 @@ describe ExportRefundNomenclature do
         end
 
         it 'loads correct description respecting given time' do
-          TimeMachine.at(1.year.ago) do
-            expect(
-              export_refund_nomenclature.export_refund_nomenclature_description.pk,
-            ).to eq export_refund_nomenclature_description1.pk
-          end
-
           TimeMachine.at(4.years.ago) do
             expect(
               export_refund_nomenclature.reload.export_refund_nomenclature_description.pk,
@@ -131,16 +109,6 @@ describe ExportRefundNomenclature do
         end
 
         it 'loads correct description respecting given time' do
-          TimeMachine.at(1.year.ago) do
-            expect(
-              described_class.where(export_refund_nomenclature_sid: export_refund_nomenclature.export_refund_nomenclature_sid)
-                          .eager(:export_refund_nomenclature_descriptions)
-                          .all
-                          .first
-                          .export_refund_nomenclature_description.pk,
-            ).to eq export_refund_nomenclature_description1.pk
-          end
-
           TimeMachine.at(4.years.ago) do
             expect(
               described_class.where(export_refund_nomenclature_sid: export_refund_nomenclature.export_refund_nomenclature_sid)

--- a/spec/models/footnote_spec.rb
+++ b/spec/models/footnote_spec.rb
@@ -29,12 +29,6 @@ describe Footnote do
         end
 
         it 'loads correct description respecting given time' do
-          TimeMachine.at(1.year.ago) do
-            expect(
-              footnote.footnote_description.pk,
-            ).to eq footnote_description_2.pk
-          end
-
           TimeMachine.at(4.years.ago) do
             expect(
               footnote.reload.footnote_description.pk,
@@ -58,17 +52,6 @@ describe Footnote do
         end
 
         it 'loads correct description respecting given time' do
-          TimeMachine.at(1.year.ago) do
-            expect(
-              described_class.where(footnote_id: footnote.footnote_id,
-                                    footnote_type_id: footnote.footnote_type_id)
-                          .eager(:footnote_descriptions)
-                          .all
-                          .first
-                          .footnote_description.pk,
-            ).to eq footnote_description_2.pk
-          end
-
           TimeMachine.at(4.years.ago) do
             expect(
               described_class.where(footnote_id: footnote.footnote_id,

--- a/spec/models/geographical_area_spec.rb
+++ b/spec/models/geographical_area_spec.rb
@@ -27,12 +27,6 @@ describe GeographicalArea do
         end
 
         it 'loads correct description respecting given time' do
-          TimeMachine.at(1.year.ago) do
-            expect(
-              geographical_area.geographical_area_description.pk,
-            ).to eq geographical_area_description1.pk
-          end
-
           TimeMachine.at(4.years.ago) do
             expect(
               geographical_area.reload.geographical_area_description.pk,
@@ -108,12 +102,6 @@ describe GeographicalArea do
         end
 
         it 'loads correct description respecting given time' do
-          TimeMachine.at(1.year.ago) do
-            expect(
-              geographical_area.contained_geographical_areas.map(&:pk),
-            ).to include contained_area_present.pk
-          end
-
           TimeMachine.at(4.years.ago) do
             expect(
               geographical_area.reload.contained_geographical_areas.map(&:pk),
@@ -137,17 +125,6 @@ describe GeographicalArea do
         end
 
         it 'loads correct description respecting given time' do
-          TimeMachine.at(1.year.ago) do
-            expect(
-              described_class.where(geographical_area_sid: geographical_area.geographical_area_sid)
-                          .eager(:contained_geographical_areas)
-                          .all
-                          .first
-                          .contained_geographical_areas(reload: true)
-                          .map(&:pk),
-            ).to include contained_area_present.pk
-          end
-
           TimeMachine.at(4.years.ago) do
             expect(
               described_class.where(geographical_area_sid: geographical_area.geographical_area_sid)

--- a/spec/models/goods_nomenclature_spec.rb
+++ b/spec/models/goods_nomenclature_spec.rb
@@ -34,12 +34,6 @@ describe GoodsNomenclature do
           end
 
           it 'loads correct indent respecting given time' do
-            TimeMachine.at(1.year.ago) do
-              expect(
-                goods_nomenclature.goods_nomenclature_indent.pk,
-              ).to eq goods_nomenclature_indent1.pk
-            end
-
             TimeMachine.at(4.years.ago) do
               expect(
                 goods_nomenclature.reload.goods_nomenclature_indent.pk,
@@ -62,16 +56,6 @@ describe GoodsNomenclature do
           end
 
           it 'loads correct indent respecting given time' do
-            TimeMachine.at(1.year.ago) do
-              expect(
-                described_class.where(goods_nomenclature_sid: goods_nomenclature.goods_nomenclature_sid)
-                            .eager(:goods_nomenclature_indents)
-                            .all
-                            .first
-                            .goods_nomenclature_indent.pk,
-              ).to eq goods_nomenclature_indent1.pk
-            end
-
             TimeMachine.at(4.years.ago) do
               expect(
                 described_class.where(goods_nomenclature_sid: goods_nomenclature.goods_nomenclature_sid)
@@ -113,12 +97,6 @@ describe GoodsNomenclature do
             end
 
             it 'loads correct description respecting given time' do
-              TimeMachine.at(1.year.ago) do
-                expect(
-                  goods_nomenclature.goods_nomenclature_description.pk,
-                ).to eq goods_nomenclature_description1.pk
-              end
-
               TimeMachine.at(4.years.ago) do
                 expect(
                   goods_nomenclature.reload.goods_nomenclature_description.pk,
@@ -141,16 +119,6 @@ describe GoodsNomenclature do
             end
 
             it 'loads correct description respecting given time' do
-              TimeMachine.at(1.year.ago) do
-                expect(
-                  described_class.where(goods_nomenclature_sid: goods_nomenclature.goods_nomenclature_sid)
-                              .eager(:goods_nomenclature_descriptions)
-                              .all
-                              .first
-                              .goods_nomenclature_description.pk,
-                ).to eq goods_nomenclature_description1.pk
-              end
-
               TimeMachine.at(4.years.ago) do
                 expect(
                   described_class.where(goods_nomenclature_sid: goods_nomenclature.goods_nomenclature_sid)
@@ -189,12 +157,6 @@ describe GoodsNomenclature do
             end
 
             it 'loads correct description respecting given time' do
-              TimeMachine.at(2.years.ago) do
-                expect(
-                  goods_nomenclature.goods_nomenclature_description.pk,
-                ).to eq goods_nomenclature_description1.pk
-              end
-
               TimeMachine.at(4.years.ago) do
                 expect(
                   goods_nomenclature.reload.goods_nomenclature_description.pk,
@@ -217,16 +179,6 @@ describe GoodsNomenclature do
             end
 
             it 'loads correct description respecting given time' do
-              TimeMachine.at(2.years.ago) do
-                expect(
-                  described_class.where(goods_nomenclature_sid: goods_nomenclature.goods_nomenclature_sid)
-                              .eager(:goods_nomenclature_descriptions)
-                              .all
-                              .first
-                              .goods_nomenclature_description.pk,
-                ).to eq goods_nomenclature_description1.pk
-              end
-
               TimeMachine.at(4.years.ago) do
                 expect(
                   described_class.where(goods_nomenclature_sid: goods_nomenclature.goods_nomenclature_sid)
@@ -294,12 +246,6 @@ describe GoodsNomenclature do
         end
 
         it 'loads correct indent respecting given time' do
-          TimeMachine.at(1.year.ago) do
-            expect(
-              goods_nomenclature.footnote.pk,
-            ).to eq footnote1.pk
-          end
-
           TimeMachine.at(4.years.ago) do
             expect(
               goods_nomenclature.reload.footnote.pk,
@@ -322,16 +268,6 @@ describe GoodsNomenclature do
         end
 
         it 'loads correct indent respecting given time' do
-          TimeMachine.at(1.year.ago) do
-            expect(
-              described_class.where(goods_nomenclature_sid: goods_nomenclature.goods_nomenclature_sid)
-                          .eager(:footnotes)
-                          .all
-                          .first
-                          .footnote.pk,
-            ).to eq footnote1.pk
-          end
-
           TimeMachine.at(4.years.ago) do
             expect(
               described_class.where(goods_nomenclature_sid: goods_nomenclature.goods_nomenclature_sid)
@@ -365,18 +301,6 @@ describe GoodsNomenclature do
       end
 
       it 'loads associated national measurement unit set' do
-        TimeMachine.at(1.year.ago) do
-          nset = described_class.where(goods_nomenclature_sid: gono.goods_nomenclature_sid)
-                        .first
-                        .national_measurement_unit_set
-
-          expect(nset.second_quantity_code).to eq tbl1.tbl_code
-          expect(nset.second_quantity_description).to eq tbl1.tbl_txt
-
-          expect(nset.third_quantity_code).to eq tbl2.tbl_code
-          expect(nset.third_quantity_description).to eq tbl2.tbl_txt
-        end
-
         TimeMachine.at(4.years.ago) do
           nset = described_class.where(goods_nomenclature_sid: gono.goods_nomenclature_sid)
                         .first

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -313,12 +313,6 @@ describe Measure do
         end
 
         it 'loads correct indent respecting given time' do
-          TimeMachine.at(1.year.ago) do
-            expect(
-              measure.footnotes.map(&:pk),
-            ).to include footnote1.pk
-          end
-
           TimeMachine.at(4.years.ago) do
             expect(
               measure.reload.footnotes.map(&:pk),
@@ -371,16 +365,6 @@ describe Measure do
         end
 
         it 'loads correct indent respecting given time' do
-          TimeMachine.at(1.year.ago) do
-            expect(
-              described_class.where(measure_sid: measure.measure_sid)
-                          .eager(:footnotes)
-                          .all
-                          .first
-                          .footnotes(reload: true).map(&:pk),
-            ).to include footnote1.pk
-          end
-
           TimeMachine.at(4.years.ago) do
             expect(
               described_class.where(measure_sid: measure.measure_sid)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -21,7 +21,9 @@ require Rails.root.join('spec/support/tariff_validation_matcher.rb')
 Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
 # require models and serializers
+require 'clearable'
 Dir[Rails.root.join('app/models/*.rb')].each { |f| require f }
+# Dir[Rails.root.join('app/models/concerns/*rb')].each { |f| require concern }
 Dir[Rails.root.join('app/serializers/*.rb')].each { |f| require f }
 
 RSpec.configure do |config|
@@ -61,11 +63,12 @@ RSpec.configure do |config|
       Chief::Tamf,
       ExportRefundNomenclature,
       Footnote,
+      GeographicalArea,
       GoodsNomenclature,
+      Measure,
       QuotaOrderNumber,
     ]
 
     clearable_models.map(&:clear_association_cache)
   end
 end
-

--- a/spec/support/shared_examples/association_shared_examples.rb
+++ b/spec/support/shared_examples/association_shared_examples.rb
@@ -38,12 +38,6 @@ shared_examples_for 'one to one to' do |associated_object, eager_load_associatio
     end
 
     it "loads correct #{associated_object.to_s.humanize} respecting given time" do
-      TimeMachine.at(1.year.ago) do
-        expect(
-          send(source_record).send(associated_object).pk,
-        ).to eq send(:"#{associated_object}1").pk
-      end
-
       TimeMachine.at(4.years.ago) do
         expect(
           send(source_record).reload.send(associated_object).pk,
@@ -76,16 +70,6 @@ shared_examples_for 'one to one to' do |associated_object, eager_load_associatio
     end
 
     it "loads correct #{associated_object.to_s.humanize} respecting given time" do
-      TimeMachine.at(1.year.ago) do
-        expect(
-          described_class.where(association_conditions)
-                       .eager(eager_load_association)
-                       .all
-                       .first
-                       .send(associated_object).pk,
-        ).to eq send(:"#{associated_object}1").pk
-      end
-
       TimeMachine.at(4.years.ago) do
         expect(
           described_class.where(association_conditions)


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-359

### What?

I have added/removed/altered:

- [x] Removes redundant/misleading duplicate expectations of the TimeMachine.

### Why?

These tests duplicate a test of the same behaviour.

These tests were leading to the false assumption that we needed to disable the benefits of eager loading/caching associations and forcibly reload all subsequent associations - causing a significantly diminished performance of our apis (760 queries instead of a normal 60).

What's actually happening is the cache inside of each of the AssociationReflection classes that are pegged to each model didn't recognise TimeMachine filters as needing to create a unique key.

I suspect we could rework the TimeMachine in future so this was enabled - I'd need to investigate this.