### PR TITLE
[HOTT-281] Fixes chained <br> tags in GoodsNomenclatureDescription

### DIFF
--- a/app/models/goods_nomenclature_description.rb
+++ b/app/models/goods_nomenclature_description.rb
@@ -20,6 +20,10 @@ class GoodsNomenclatureDescription < Sequel::Model
   format :formatted_description, with: DescriptionFormatter,
                                  using: :description
 
+  def description
+    super.gsub(%r/( ?<br> ?){2,}/, '<br>')
+  end
+
   def formatted_description
     super.mb_chars.downcase.to_s.gsub(/^(.)/) { $1.capitalize }
   end

--- a/spec/models/goods_nomenclature_description_spec.rb
+++ b/spec/models/goods_nomenclature_description_spec.rb
@@ -1,6 +1,41 @@
 require 'rails_helper'
 
 describe GoodsNomenclatureDescription do
+  describe '#description' do
+    subject(:goods_nomenclature_description) { build :goods_nomenclature_description, description: description }
+
+    context 'when the description value has multiple chained <br><br><br>tags' do
+      let(:description) do
+        'Additives containing<br> <br><br><br>- overbased magnesium (C20-C24) alkylbenzenesulphonates (CAS RN 231297-75-9) and<br> <br><br><br>- by weight more than 25 % but not more than 50 % of mineral oils,<br>having a total base number of more than 350, but not more than 450, for use in the manufacture of lubricating oils'
+      end
+
+      it 'replaces the chain of <br> tags with a single <br> tag' do
+        expected = 'Additives containing<br>- overbased magnesium (C20-C24) alkylbenzenesulphonates (CAS RN 231297-75-9) and<br>- by weight more than 25 % but not more than 50 % of mineral oils,<br>having a total base number of more than 350, but not more than 450, for use in the manufacture of lubricating oils'
+        expect(goods_nomenclature_description.description).to eq(expected)
+      end
+    end
+
+    context 'when the description value has only single <br> tag chains' do
+      let(:description) do
+        'Additives containing<br>- overbased magnesium (C20-C24) alkylbenzenesulphonates (CAS RN 231297-75-9) and<br>- by weight more than 25 % but not more than 50 % of mineral oils,<br>having a total base number of more than 350, but not more than 450, for use in the manufacture of lubricating oils'
+      end
+
+      it 'does not change the description' do
+        expect(goods_nomenclature_description.description).to eq(description)
+      end
+    end
+
+    context 'when the description value has no <br> tags' do
+      let(:description) do
+        'Additives containing - overbased magnesium (C20-C24) alkylbenzenesulphonates (CAS RN 231297-75-9) and - by weight more than 25 % but not more than 50 % of mineral oils,having a total base number of more than 350, but not more than 450, for use in the manufacture of lubricating oils'
+      end
+
+      it 'does not change the description' do
+        expect(goods_nomenclature_description.description).to eq(description)
+      end
+    end
+  end
+
   describe '#to_s' do
     let(:gono_description) { build :goods_nomenclature_description }
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-281

### What?

I have added/removed/altered:

- [x] Replace `<br>` chains with a single `<br>` in GoodsNomenclatureDescription

### Why?

I am doing this because:

- The data is broken slightly in production
