### PR TITLE
Adjust ETL logic as follows

### DIFF
--- a/lib/cds_importer/entity_mapper.rb
+++ b/lib/cds_importer/entity_mapper.rb
@@ -62,7 +62,7 @@ class CdsImporter
     def remove_excluded_geographical_areas!
       return if xml_node['sid'].blank?
 
-      MeasureExcludedGeographicalArea.where(measure_sid: xml_node['sid']).delete
+      MeasureExcludedGeographicalArea.operation_klass.where(measure_sid: xml_node['sid']).delete
     end
 
     def transform!

--- a/lib/cds_importer/entity_mapper.rb
+++ b/lib/cds_importer/entity_mapper.rb
@@ -21,6 +21,8 @@ class CdsImporter
                            .sort_by { |m| m.mapping_path ? m.mapping_path.length : 0 }
 
       mappers.each do |mapper|
+        remove_excluded_geographical_areas! if mapper == CdsImporter::EntityMapper::MeasureMapper
+
         transform! if mapper == CdsImporter::EntityMapper::GeographicalAreaMembershipMapper
 
         instances = mapper.new(xml_node).parse
@@ -57,8 +59,14 @@ class CdsImporter
       nil
     end
 
+    def remove_excluded_geographical_areas!
+      return if xml_node['sid'].blank?
+
+      MeasureExcludedGeographicalArea.where(measure_sid: xml_node['sid']).delete
+    end
+
     def transform!
-      return unless xml_node.has_key?('geographicalAreaMembership')
+      return unless xml_node.key?('geographicalAreaMembership')
 
       mutate_geographical_area_membership_node!
     end
@@ -67,8 +75,7 @@ class CdsImporter
       convert_single_geo_area_member_to_array!
 
       xml_node['geographicalAreaMembership'] = xml_node['geographicalAreaMembership'].each_with_object([]) do |geographical_area_membership, array|
-
-        next unless geographical_area_membership.has_key?('geographicalAreaGroupSid')
+        next unless geographical_area_membership.key?('geographicalAreaGroupSid')
 
         geographical_area = GeographicalArea[hjid: geographical_area_membership['geographicalAreaGroupSid']]
 
@@ -84,7 +91,7 @@ class CdsImporter
     end
 
     def convert_single_geo_area_member_to_array!
-      return if xml_node['geographicalAreaMembership'].kind_of?(Array)
+      return if xml_node['geographicalAreaMembership'].is_a?(Array)
 
       xml_node['geographicalAreaMembership'] = [xml_node['geographicalAreaMembership']]
     end

--- a/lib/sequel/plugins/oplog.rb
+++ b/lib/sequel/plugins/oplog.rb
@@ -127,6 +127,10 @@ module Sequel
         def insert
           raise NotImplementedError.new('You should be inserting model instances.')
         end
+
+        def delete
+          raise NotImplementedError.new('You should be *destroying* model instances.')
+        end
       end
     end
   end

--- a/lib/sequel/plugins/oplog.rb
+++ b/lib/sequel/plugins/oplog.rb
@@ -127,10 +127,6 @@ module Sequel
         def insert
           raise NotImplementedError.new('You should be inserting model instances.')
         end
-
-        def delete
-          raise NotImplementedError.new('You should be *destroying* model instances.')
-        end
       end
     end
   end

--- a/spec/integration/cds_importer/entity_mapper_spec.rb
+++ b/spec/integration/cds_importer/entity_mapper_spec.rb
@@ -139,6 +139,18 @@ describe CdsImporter::EntityMapper do
         expect(MeasureExcludedGeographicalArea[measure_sid: other_exclusion.measure_sid]).to be_present
       end
 
+      context 'when there is an existing exclusion for this measure' do # rubocop:disable RSpec/NestedGroups
+        it 'does a hard delete of that exclusion' do
+          create(:geographical_area, geographical_area_sid: '439')
+
+          create(:measure_excluded_geographical_area, measure_sid: '20130650', excluded_geographical_area: 'IT')
+
+          mapper.import
+
+          expect(MeasureExcludedGeographicalArea[excluded_geographical_area: 'IT']).not_to be_present
+        end
+      end
+
       it 'does recreate the excluded geographical areas contained within the XML increment' do
         create(:geographical_area, geographical_area_sid: '439')
 
@@ -147,7 +159,7 @@ describe CdsImporter::EntityMapper do
         }.to change(MeasureExcludedGeographicalArea, :count).from(0).to(1)
       end
 
-      it 'does persists the correct excluded geographical area from the XML increment' do
+      it 'does persist the correct excluded geographical area from the XML increment' do
         create(:geographical_area, geographical_area_sid: '439')
 
         mapper.import

--- a/spec/integration/cds_importer/entity_mapper_spec.rb
+++ b/spec/integration/cds_importer/entity_mapper_spec.rb
@@ -24,9 +24,11 @@ describe CdsImporter::EntityMapper do
     stub_const(
       'CdsImporter::EntityMapper::ALL_MAPPERS',
       [
+        CdsImporter::EntityMapper::MeasureMapper,
+        CdsImporter::EntityMapper::MeasureExcludedGeographicalAreaMapper,
         CdsImporter::EntityMapper::AdditionalCodeMapper,
         CdsImporter::EntityMapper::GeographicalAreaMapper,
-        CdsImporter::EntityMapper::GeographicalAreaMembershipMapper
+        CdsImporter::EntityMapper::GeographicalAreaMembershipMapper,
       ]
     )
   end
@@ -89,6 +91,69 @@ describe CdsImporter::EntityMapper do
     it 'assigns filename' do
       mapper.import
       expect(AdditionalCode.last.filename).to eq 'test.gzip'
+    end
+
+    context 'when measureExcludedGeographicalArea changes are present' do
+      let(:xml_node) do
+        {
+          'sid' => '20130650',
+          'validityStartDate' => '2021-01-01T00:00:00',
+          'metainfo' => {
+            'opType' => 'C',
+            'origin' => 'T',
+            'status' => 'L',
+            'transactionDate' => '2021-02-01T17:42:46',
+          },
+          'measureExcludedGeographicalArea' =>
+          [
+            {
+              'metainfo' => {
+                'opType' => 'C',
+                'origin' => 'T',
+                'status' => 'L',
+                'transactionDate' => '2021-02-01T17:42:46',
+              },
+              'geographicalArea' => {
+                'hjid' => '23808',
+                'sid' => '439',
+                'geographicalAreaId' => 'CN',
+                'validityStartDate' => '1984-01-01T00:00:00',
+              },
+            },
+          ],
+        }
+      end
+
+      let(:mapper) { described_class.new('Measure', xml_node) }
+
+      let(:measure) {
+        create(:measure, measure_sid: '20130650')
+      }
+
+      it 'does not remove excluded geographical areas that belong to measures not present within the XML increment' do
+        create(:geographical_area, geographical_area_sid: '439')
+        other_exclusion = create(:measure_excluded_geographical_area)
+
+        mapper.import
+
+        expect(MeasureExcludedGeographicalArea[measure_sid: other_exclusion.measure_sid]).to be_present
+      end
+
+      it 'does recreate the excluded geographical areas contained within the XML increment' do
+        create(:geographical_area, geographical_area_sid: '439')
+
+        expect {
+          mapper.import
+        }.to change(MeasureExcludedGeographicalArea, :count).from(0).to(1)
+      end
+
+      it 'does persists the correct excluded geographical area from the XML increment' do
+        create(:geographical_area, geographical_area_sid: '439')
+
+        mapper.import
+
+        expect(MeasureExcludedGeographicalArea.last.measure_sid).to eq(20130650)
+      end
     end
   end
 end

--- a/spec/integration/cds_importer/entity_mapper_spec.rb
+++ b/spec/integration/cds_importer/entity_mapper_spec.rb
@@ -152,7 +152,11 @@ describe CdsImporter::EntityMapper do
 
         mapper.import
 
-        expect(MeasureExcludedGeographicalArea.last.measure_sid).to eq(20130650)
+        expect(MeasureExcludedGeographicalArea.last).to have_attributes(
+          measure_sid: 20_130_650,
+          excluded_geographical_area: 'CN',
+          geographical_area_sid: 439,
+        )
       end
     end
   end


### PR DESCRIPTION
### Jira link

HOTT-416
### What?

- when we have Measures coming through, we delete all
corresponding geographical areas exclusions
- if the XML increment file contains any exclusions they
will be recreated

### Why?

CDS no longer sends exclusions with operation type D, instead, the records will be completely missing.