### PR TITLE
Force ttl of headings, chemical search and commodities to 24 hours

### DIFF
--- a/app/controllers/api/v2/commodities_controller.rb
+++ b/app/controllers/api/v2/commodities_controller.rb
@@ -5,7 +5,7 @@ module Api
 
       def show
         @commodity_cache_key = "commodity-#{@commodity.goods_nomenclature_sid}-#{actual_date}-#{TradeTariffBackend.currency}"
-        serializable_hash = Rails.cache.fetch('_' + @commodity_cache_key, expires_in: TradeTariffBackend.seconds_till_6am) do
+        serializable_hash = Rails.cache.fetch('_' + @commodity_cache_key, expires_in: 24.hours) do
           @measures = MeasurePresenter.new(
             @commodity.measures_dataset.eager(
               { footnotes: :footnote_descriptions },

--- a/app/services/chemical_search_service.rb
+++ b/app/services/chemical_search_service.rb
@@ -56,7 +56,7 @@ class ChemicalSearchService
   end
 
   def cache_expiry(seconds = nil)
-    seconds || TradeTariffBackend.seconds_till_6am
+    seconds || 24.hours
   end
 
   def cas_cleaned

--- a/app/services/heading_service/heading_serialization_service.rb
+++ b/app/services/heading_service/heading_serialization_service.rb
@@ -10,7 +10,7 @@ module HeadingService
     def serializable_hash
       heading_cache_key = "heading-#{TradeTariffBackend.service}-#{heading.goods_nomenclature_sid}-#{actual_date}-#{TradeTariffBackend.currency}-#{heading.declarable?}"
       if heading.declarable?
-        Rails.cache.fetch('_' + heading_cache_key, expires_in: TradeTariffBackend.seconds_till_6am) do
+        Rails.cache.fetch('_' + heading_cache_key, expires_in: 24.hours) do
           @measures = MeasurePresenter.new(heading.measures_dataset.eager({geographical_area: [:geographical_area_descriptions,
                                                                                                 { contained_geographical_areas: :geographical_area_descriptions }]},
                                                                            {footnotes: :footnote_descriptions},
@@ -65,7 +65,7 @@ module HeadingService
           Api::V2::Headings::DeclarableHeadingSerializer.new(presenter, options).serializable_hash
         end
       else
-        Rails.cache.fetch('_' + heading_cache_key, expires_in: TradeTariffBackend.seconds_till_6am) do
+        Rails.cache.fetch('_' + heading_cache_key, expires_in: 24.hours) do
           service = HeadingService::CachedHeadingService.new(heading, actual_date)
           hash = service.serializable_hash
           options = { is_collection: false }

--- a/app/workers/clear_cache_worker.rb
+++ b/app/workers/clear_cache_worker.rb
@@ -1,8 +1,8 @@
 class ClearCacheWorker
   include Sidekiq::Worker
-  
+
   sidekiq_options retry: false
-  
+
   def perform
     logger.info 'Clearing Rails cache'
     Rails.cache.clear

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -25,7 +25,7 @@
     cron: "0 14 * * 6" # 14:00 every Saturday
     description: "TaricSequenceCheckWorker will run every Saturday at 14:00."
   ClearCacheWorker:
-    cron: "0 0 * * *" # 00:00 every day
+    cron: "30 2 * * *" # 02:30 every day
     description: "Clear Rails cache at midnight"
   RecacheModelsWorker:
     cron: "30 2 * * *" # 02:30 every day

--- a/lib/trade_tariff_backend.rb
+++ b/lib/trade_tariff_backend.rb
@@ -116,10 +116,6 @@ module TradeTariffBackend
       end
     end
 
-    def seconds_till_6am
-      Time.now.end_of_day + 6.hours - Time.now
-    end
-
     # Number of changes to fetch for Commodity/Heading/Chapter
     def change_count
       10


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Fix headings, chemical search and commodities in v2 to be a static 24 hours
- [x] Set the schedule for the recache to be after the import

### Why?

I am doing this because:

- We invalidate the redis cache on a schedule way before this time so this is completely redundant.
- The logic and naming of this method were just wrong, too.

### Deployment risks (optional)

- The combination of performance enhancements and the fact that these caches get invalidated every night anyway diminish the risk around this change
