### PR TITLE
Reschedule Redis cache clear

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -25,7 +25,7 @@
     cron: "0 14 * * 6" # 14:00 every Saturday
     description: "TaricSequenceCheckWorker will run every Saturday at 14:00."
   ClearCacheWorker:
-    cron: "0 0 * * *" # 00:00 every day
+    cron: "0 3 * * *" # 03:00 every day
     description: "Clear Rails cache at midnight"
   RecacheModelsWorker:
     cron: "30 2 * * *" # 02:30 every day


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

Our ETL process kicks in at 2:00 AM. The Redis cache needs
to be invalidated after the data load.

### Why?

Reduce cache related issues in the morning.