### PR TITLE
[HOTT-351] Warn on guard clauses in cds importer flow

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,6 +26,8 @@ Metrics/ModuleLength:
   Enabled: false
 RSpec/ExampleLength:
   Enabled: false
+RSpec/NestedGroups:
+  Enabled: false
 Rails/SaveBang:
   Enabled: false
 Rails/FilePath:

--- a/app/views/tariff_synchronizer/mailer/applied.html.erb
+++ b/app/views/tariff_synchronizer/mailer/applied.html.erb
@@ -85,3 +85,31 @@
     <strong>No presence errors found.</strong>
   </p>
 <% end %>
+
+<% if @import_warnings.any? %>
+  <table>
+    <thead>
+    <tr>
+      <th>Message</th>
+      <th>XML Node</th>
+    </tr>
+    </thead>
+    <tbody>
+    <% @import_warnings.each do |warning| %>
+      <tr>
+        <td>
+          <%= warning[:message] %>
+        </td>
+
+        <td>
+          <%= warning[:xml_node] %>
+        </td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <p>
+    <strong>No import warnings found.</strong>
+  </p>
+<% end %>

--- a/lib/cds_importer/entity_mapper.rb
+++ b/lib/cds_importer/entity_mapper.rb
@@ -60,7 +60,13 @@ class CdsImporter
     end
 
     def remove_excluded_geographical_areas!
-      return if xml_node['sid'].blank?
+      if xml_node['sid'].blank?
+        message = 'Skipping removal of measure geographical exclusions due to missing measure sid.'
+
+        instrument_warning(message, xml_node)
+
+        return
+      end
 
       MeasureExcludedGeographicalArea.operation_klass.where(measure_sid: xml_node['sid']).delete
     end
@@ -75,7 +81,12 @@ class CdsImporter
       convert_single_geo_area_member_to_array!
 
       xml_node['geographicalAreaMembership'] = xml_node['geographicalAreaMembership'].each_with_object([]) do |geographical_area_membership, array|
-        next unless geographical_area_membership.key?('geographicalAreaGroupSid')
+        unless geographical_area_membership.key?('geographicalAreaGroupSid')
+          message = "Skipping membership import due to missing geographical area sid\n\n#{JSON.pretty_generate(geographical_membership)}\n"
+
+          instrument_warning(message, xml_node)
+          next
+        end
 
         geographical_area = GeographicalArea[hjid: geographical_area_membership['geographicalAreaGroupSid']]
 
@@ -94,6 +105,10 @@ class CdsImporter
       return if xml_node['geographicalAreaMembership'].is_a?(Array)
 
       xml_node['geographicalAreaMembership'] = [xml_node['geographicalAreaMembership']]
+    end
+
+    def instrument_warning(message, xml_node)
+      instrument('apply.import_warnings', message: message, xml_node: xml_node)
     end
   end
 end

--- a/lib/cds_importer/entity_mapper.rb
+++ b/lib/cds_importer/entity_mapper.rb
@@ -82,7 +82,7 @@ class CdsImporter
 
       xml_node['geographicalAreaMembership'] = xml_node['geographicalAreaMembership'].each_with_object([]) do |geographical_area_membership, array|
         unless geographical_area_membership.key?('geographicalAreaGroupSid')
-          message = "Skipping membership import due to missing geographical area sid\n\n#{JSON.pretty_generate(geographical_membership)}\n"
+          message = "Skipping membership import due to missing geographical area sid\n\n#{JSON.pretty_generate(geographical_area_membership)}\n"
 
           instrument_warning(message, xml_node)
           next

--- a/lib/cds_importer/entity_mapper.rb
+++ b/lib/cds_importer/entity_mapper.rb
@@ -82,7 +82,7 @@ class CdsImporter
 
       xml_node['geographicalAreaMembership'] = xml_node['geographicalAreaMembership'].each_with_object([]) do |geographical_area_membership, array|
         unless geographical_area_membership.key?('geographicalAreaGroupSid')
-          message = "Skipping membership import due to missing geographical area sid\n\n#{JSON.pretty_generate(geographical_area_membership)}\n"
+          message = "Skipping membership import due to missing geographical area group sid. hjid is #{geographical_area_membership['hjid']}\n"
 
           instrument_warning(message, xml_node)
           next

--- a/lib/tariff_synchronizer/logger.rb
+++ b/lib/tariff_synchronizer/logger.rb
@@ -21,7 +21,8 @@ module TariffSynchronizer
 
       Mailer.applied(
         event.payload[:update_names],
-        event.payload.fetch(:unconformant_records, [])
+        event.payload.fetch(:unconformant_records, []),
+        event.payload.fetch(:import_warnings, []),
       ).deliver_now
     end
 
@@ -36,7 +37,7 @@ module TariffSynchronizer
       Mailer.exception(
         event.payload[:exception],
         event.payload[:update],
-        event.payload[:database_queries]
+        event.payload[:database_queries],
       ).deliver_now
     end
 

--- a/lib/tariff_synchronizer/mailer.rb
+++ b/lib/tariff_synchronizer/mailer.rb
@@ -54,9 +54,10 @@ module TariffSynchronizer
       mail subject: "#{subject_prefix(:error)} Update fetch failed: cannot write update file to file system"
     end
 
-    def applied(update_names, conformance_errors = [])
+    def applied(update_names, conformance_errors, import_warnings)
       @update_names = update_names
       @conformance_errors = conformance_errors
+      @import_warnings = import_warnings
       # if 'presence errors' are ignored during tariff update then we can display them in email body
       if TariffSynchronizer.ignore_presence_errors
         @presence_errors = TariffSynchronizer::TariffUpdatePresenceError.where(tariff_update_filename: update_names)

--- a/spec/unit/tariff_synchronizer_spec.rb
+++ b/spec/unit/tariff_synchronizer_spec.rb
@@ -110,6 +110,7 @@ describe TariffSynchronizer, truncation: true do
         expect(ActionMailer::Base.deliveries).not_to be_empty
         expect(ActionMailer::Base.deliveries.last.subject).to include('Tariff updates applied')
         expect(ActionMailer::Base.deliveries.last.encoded).to include('No conformance errors found.')
+        expect(ActionMailer::Base.deliveries.last.encoded).to include('No import warnings found.')
       end
     end
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-351

### What?

I have added/removed/altered:

- [x] Adds warnings about missing references to email report that comes in after a successful apply

### Why?

I am doing this because:

- We want to have some way of knowing when we've skipped a transform or
exclusion clobbering due to missing references.
- This should be super rare but we want to know about it because it could
indicate data issues upstream
