### PR TITLE
[HOTT-426] Clears association cache on all known problem models before a request

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   respond_to :json, :html
 
+  before_action :clear_association_queries
   around_action :configure_time_machine
 
   unless Rails.application.config.consider_all_requests_local
@@ -58,5 +59,9 @@ class ApplicationController < ActionController::Base
     TimeMachine.at(actual_date) do
       yield
     end
+  end
+
+  def clear_association_queries
+    TradeTariffBackend.clearable_models.map(&:clear_association_cache)
   end
 end

--- a/lib/trade_tariff_backend.rb
+++ b/lib/trade_tariff_backend.rb
@@ -169,6 +169,19 @@ module TradeTariffBackend
       [Heading, Certificate, AdditionalCode, Footnote]
     end
 
+    def clearable_models
+      [
+        Certificate,
+        Chief::Tamf,
+        ExportRefundNomenclature,
+        Footnote,
+        GeographicalArea,
+        GoodsNomenclature,
+        Measure,
+        QuotaOrderNumber,
+      ]
+    end
+
     def search_indexes
       indexed_models.map { |model|
         "::Search::#{model}Index".constantize.new(search_namespace)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -58,17 +58,6 @@ RSpec.configure do |config|
     Rails.cache.clear
     Sidekiq::Worker.clear_all
 
-    clearable_models = [
-      Certificate,
-      Chief::Tamf,
-      ExportRefundNomenclature,
-      Footnote,
-      GeographicalArea,
-      GoodsNomenclature,
-      Measure,
-      QuotaOrderNumber,
-    ]
-
-    clearable_models.map(&:clear_association_cache)
+    TradeTariffBackend.clearable_models.map(&:clear_association_cache)
   end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-426

### What?

I have added/removed/altered:

- [x] Clear the class level Sequel association cache of known problem models before each request

### Why?

We know that association queries get cached and don't recognise that the
time machine should represent a change in the stored query.

Weirdly this affects only a subset of models that are invoked with the
TimeMachine.

I'd need to further dig into the specifics to understand why this is but
I know for a fact that the class level cache needs invalidating when we
want to change the actual date.

It's important to know that data gets stored in lexical scope under an
instance of a Sequel query result not in the class cache that we're
clearing here. What we're clearing is explicitly the query itself which
is reused between runs to (I suspect) save Sequel a smidge of time in
generating the output SQL as driven by invoking the sequel model and
dataset methods.

I am doing this because:

- We know the class level association cache doesn't recognise TimeMachine changing the cache key and needs clearing
- We don't want to revert to using reload and forcing our application to grind to a halt/propagate timeout exceptions and introduce lots of n+1s

We can revert this change very quickly and it is non-data-affecting - well it should reduce the issue of the association cache causing increasing data malforms.