### PR TITLE
[HOTT-422] Adds measurement_unit_qualifier_code to the V2 MeasureComponentSerializer

### DIFF
--- a/app/serializers/api/v2/measures/measure_component_serializer.rb
+++ b/app/serializers/api/v2/measures/measure_component_serializer.rb
@@ -10,8 +10,14 @@ module Api
           obj.pk.join('-')
         end
 
-        attributes :duty_expression_id, :duty_amount, :monetary_unit_code, :monetary_unit_abbreviation,
-                   :measurement_unit_code, :duty_expression_description, :duty_expression_abbreviation
+        attributes :duty_expression_id,
+                   :duty_amount,
+                   :monetary_unit_code,
+                   :monetary_unit_abbreviation,
+                   :measurement_unit_code,
+                   :duty_expression_description,
+                   :duty_expression_abbreviation,
+                   :measurement_unit_qualifier_code
       end
     end
   end

--- a/spec/serializers/api/v2/measure_component_serializer_spec.rb
+++ b/spec/serializers/api/v2/measure_component_serializer_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+describe Api::V2::Measures::MeasureComponentSerializer do
+  let(:measure_component) do
+    create(
+      :measure_component,
+      duty_expression_id: duty_expression.duty_expression_id,
+      duty_amount: 10.0,
+      monetary_unit_code: 'foo',
+      measurement_unit_code: 'bar',
+      measurement_unit_qualifier_code: 'a',
+    )
+  end
+
+  let(:duty_expression) { create(:duty_expression, :with_description) }
+
+  let(:expected_pattern) do
+    {
+      data: {
+        id: measure_component.pk.join('-'),
+        type: :measure_component,
+        attributes: {
+          duty_expression_id: duty_expression.duty_expression_id,
+          duty_amount: 10.0,
+          monetary_unit_code: 'foo',
+          monetary_unit_abbreviation: nil,
+          measurement_unit_code: 'bar',
+          duty_expression_description: duty_expression.description,
+          duty_expression_abbreviation: nil,
+          measurement_unit_qualifier_code: 'a',
+        },
+      },
+    }
+  end
+
+  describe '#serializable_hash' do
+    it 'serializes the correct attributes' do
+      actual = described_class.new(measure_component).serializable_hash
+      expect(actual).to include(expected_pattern)
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-422

### What?

I have added/removed/altered:

- [x] Extended the measure component serializer to include the measurement_unit_qualifier_code
- [x] Added a unit test of the serializer

### Why?

I am doing this because:

- This is needed for the measurement unit work as part of the duty calculator app