### PR TITLE
[HOTT-477] Surface contained geographical areas

### DIFF
--- a/app/controllers/api/v2/geographical_areas_controller.rb
+++ b/app/controllers/api/v2/geographical_areas_controller.rb
@@ -4,17 +4,17 @@ module Api
       def index
         @geographical_areas = GeographicalArea.eager(:geographical_area_descriptions).actual.areas.all
 
-        options = {}
-        options[:include] = [:contained_geographical_areas]
-        render json: Api::V2::GeographicalAreaTreeSerializer.new(@geographical_areas).serializable_hash
+        render json: Api::V2::GeographicalAreaTreeSerializer.new(@geographical_areas, options).serializable_hash
       end
-      
+
       def countries
         @geographical_areas = GeographicalArea.eager(:geographical_area_descriptions).actual.countries.all
 
-        options = {}
-        options[:include] = [:contained_geographical_areas]
-        render json: Api::V2::GeographicalAreaTreeSerializer.new(@geographical_areas).serializable_hash
+        render json: Api::V2::GeographicalAreaTreeSerializer.new(@geographical_areas, options).serializable_hash
+      end
+
+      def options
+        { include: [:contained_geographical_areas] }
       end
     end
   end

--- a/spec/controllers/api/v2/geographical_areas_controller_spec.rb
+++ b/spec/controllers/api/v2/geographical_areas_controller_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 describe Api::V2::GeographicalAreasController, 'GET #countries' do
-  render_views
-
   let!(:geographical_area1) do
     create :geographical_area,
            :with_description,
@@ -26,6 +24,7 @@ describe Api::V2::GeographicalAreasController, 'GET #countries' do
         { id: String, type: String, attributes: { id: String, description: String, geographical_area_id: String }, relationships: { children_geographical_areas: { data: [] } } },
         { id: String, type: String, attributes: { id: String, description: String, geographical_area_id: String }, relationships: { children_geographical_areas: { data: [] } } },
       ],
+      included: Array,
     }
   end
 
@@ -72,6 +71,7 @@ describe Api::V2::GeographicalAreasController, 'GET #countries' do
           { id: String, type: String, attributes: { id: String, description: String, geographical_area_id: String }, relationships: { children_geographical_areas: { data: [] } } },
           { id: String, type: String, attributes: { id: String, description: String, geographical_area_id: String }, relationships: { children_geographical_areas: { data: [] } } },
         ],
+        included: Array,
       }
     end
 
@@ -117,7 +117,7 @@ describe Api::V2::GeographicalAreasController, 'GET #countries' do
     let!(:parent_geographical_area) do
       create :geographical_area,
              :with_description,
-             geographical_code: '1'
+             :group
     end
     let!(:geographical_area_membership1) do
       create :geographical_area_membership,
@@ -131,73 +131,97 @@ describe Api::V2::GeographicalAreasController, 'GET #countries' do
     end
 
     let(:pattern) do
-      { data: [
-        {
-          id: String,
-          type: 'geographical_area',
-          attributes: {
+      {
+        data: [
+          {
             id: String,
-            description: String,
-            geographical_area_id: String,
-          },
-          relationships: {
-            children_geographical_areas: {
-              data: [],
+            type: 'geographical_area',
+            attributes: {
+              id: String,
+              description: String,
+              geographical_area_id: String,
+            },
+            relationships: {
+              children_geographical_areas: {
+                data: [],
+              },
             },
           },
-        },
-        {
-          id: String,
-          type: 'geographical_area',
-          attributes: {
+          {
             id: String,
-            description: String,
-            geographical_area_id: String,
-          },
-          relationships: {
-            children_geographical_areas: {
-              data: [],
+            type: 'geographical_area',
+            attributes: {
+              id: String,
+              description: String,
+              geographical_area_id: String,
+            },
+            relationships: {
+              children_geographical_areas: {
+                data: [],
+              },
             },
           },
-        },
-        {
-          id: String,
-          type: 'geographical_area',
-          attributes: {
+          {
             id: String,
-            description: String,
-            geographical_area_id: String,
-          },
-          relationships: {
-            children_geographical_areas: {
-              data: [],
+            type: 'geographical_area',
+            attributes: {
+              id: String,
+              description: String,
+              geographical_area_id: String,
+            },
+            relationships: {
+              children_geographical_areas: {
+                data: [],
+              },
             },
           },
-        },
-        {
-          id: parent_geographical_area.geographical_area_id,
-          type: 'geographical_area',
-          attributes: {
+          {
             id: parent_geographical_area.geographical_area_id,
-            description: String,
-            geographical_area_id: String,
-          },
-          relationships: {
-            children_geographical_areas: {
-              data: [
-                {
-                  id: geographical_area1.geographical_area_id,
-                  type: 'geographical_area',
-                },
-                {
-                  id: geographical_area3.geographical_area_id,
-                  type: 'geographical_area',
-                },
-              ],
+            type: 'geographical_area',
+            attributes: {
+              id: parent_geographical_area.geographical_area_id,
+              description: String,
+              geographical_area_id: String,
+            },
+            relationships: {
+              children_geographical_areas: {
+                data: [
+                  {
+                    id: geographical_area1.geographical_area_id,
+                    type: 'geographical_area',
+                  },
+                  {
+                    id: geographical_area3.geographical_area_id,
+                    type: 'geographical_area',
+                  },
+                ],
+              },
             },
           },
-        },
-      ] }
+        ],
+        included: [
+          {
+            id: geographical_area1.geographical_area_id,
+            type: 'geographical_area',
+            attributes: {
+              id: geographical_area1.geographical_area_id,
+              description: String,
+              geographical_area_id: String,
+            },
+            relationships: Hash,
+          },
+          {
+            id: geographical_area3.geographical_area_id,
+            type: 'geographical_area',
+            attributes: {
+              id: geographical_area3.geographical_area_id,
+              description: String,
+              geographical_area_id: String,
+            },
+            relationships: Hash,
+          },
+        ],
+      }
     end
 
     it 'returns rendered records' do


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-477

### What?

I have added/removed/altered:

- [x] Make sure that the geographical areas endpoint returns the contained geographical areas in the included list by fixing the options that are passed to the json api serializer

### Why?

I am doing this because:

- We want to know the members of the European Union in the Duty Calculator and this is currently not possible